### PR TITLE
Analyze socket connection lifecycle

### DIFF
--- a/backend/chatservice/src/socket/index.ts
+++ b/backend/chatservice/src/socket/index.ts
@@ -67,31 +67,18 @@ export function setupSocketServer(io: Server) {
   // 鉴权中间件：兼容 payload.userId / payload.sub
   io.use((socket, next) => {
     const token = socket.handshake.auth?.token as string | undefined;
-    const fallbackUserId = socket.handshake.auth?.userId as string | undefined;
     if (!token) {
-      if (fallbackUserId) {
-        (socket as SocketWithAuth).data = { userId: String(fallbackUserId) };
-        return next();
-      }
       return next(new Error('No token provided'));
     }
     try {
       const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JWTPayload;
       const uid = String(decoded.userId ?? decoded.sub ?? '');
       if (!uid) {
-        if (fallbackUserId) {
-          (socket as SocketWithAuth).data = { userId: String(fallbackUserId) };
-          return next();
-        }
         return next(new Error('Invalid token payload'));
       }
       (socket as SocketWithAuth).data = { userId: uid };
       next();
     } catch (e) {
-      if (fallbackUserId) {
-        (socket as SocketWithAuth).data = { userId: String(fallbackUserId) };
-        return next();
-      }
       next(new Error('Invalid token'));
     }
   });

--- a/backend/chatservice/src/socket/index.ts
+++ b/backend/chatservice/src/socket/index.ts
@@ -16,26 +16,15 @@ const heartbeats = new Map<string, NodeJS.Timeout>(); // 心跳定时器，按 s
 function roomOf(userId: string) { return `u:${userId}`; }
 function threadRoom(threadId: string) { return `room:${threadId}`; } // 保留工具函数，当前未使用线程广播
 
-function mask(str: string, show = 6) {
-  if (!str) return '';
-  if (str.length <= show * 2) return '*'.repeat(str.length);
-  return str.slice(0, show) + '...' + str.slice(-show);
-}
 
-function peekJwt(token: string) {
-  try {
-    const decoded = (jwt as any).decode(token, { complete: true }) as any;
-    return {
-      alg: decoded?.header?.alg,
-      kid: decoded?.header?.kid,
-      exp: decoded?.payload?.exp,
-      iat: decoded?.payload?.iat,
-      sub: decoded?.payload?.sub,
-      userId: decoded?.payload?.userId,
-    };
-  } catch {
-    return null;
-  }
+async function recomputeOnline(io: Server, userId: string) {
+  const sockets = await io.in(`u:${userId}`).fetchSockets();
+  const conn = sockets.length;
+  await redis.hset(`user:${userId}`, {
+    conn,
+    online: conn > 0 ? 1 : 0,
+    lastOnlineAt: Date.now(),
+  });
 }
 
 function bindSocket(userId: string, socketId: string) {
@@ -91,11 +80,16 @@ export function setupSocketServer(io: Server) {
     // 加入以用户为维度的房间，便于跨实例广播
     await socket.join(roomOf(userId));
 
+    
+
     // —— 标记在线与心跳（心跳只更新时间） ——
+    await recomputeOnline(io, userId);
+    /*
     try {
       await redis.hincrby(`user:${userId}`, 'conn', 1); // 连接计数 +1
       await redis.hset(`user:${userId}`, { online: 1, lastOnlineAt: Date.now() });
     } catch {}
+     */
     // 防重复启动
     if (heartbeats.has(socket.id)) clearInterval(heartbeats.get(socket.id)!);
     const hb = setInterval(async () => {
@@ -260,7 +254,8 @@ export function setupSocketServer(io: Server) {
         heartbeats.delete(socket.id);
       }
 
-      // 连接计数 -1；归零才置 offline
+      // 连接计数 -1；归零才置 offline\
+      /*
       try {
         const c = await redis.hincrby(`user:${userId}`, 'conn', -1);
         if (c <= 0) {
@@ -269,8 +264,10 @@ export function setupSocketServer(io: Server) {
           await redis.hset(`user:${userId}`, { lastOnlineAt: Date.now() });
         }
       } catch {}
-
+      */
+     
       try { await socket.leave(roomOf(userId)); } catch {}
+      await recomputeOnline(io, userId);
     });
   });
 }

--- a/frontend/src/contexts/UserContext.tsx
+++ b/frontend/src/contexts/UserContext.tsx
@@ -2,6 +2,8 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { getUserProfile } from "@/api/user";
 import { supabase } from "@/lib/supabase";
 import type { User, UserProfile } from "@/entities/user";
+import { useChatDockStore } from "@/pages/community/chatDock/store";
+import { useCommunityStore } from "@/pages/community/store";
 
 interface UserContextType {
   user: User | null;
@@ -46,6 +48,8 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
 
         if (!session) {
           apply(null, null);
+          try { useChatDockStore.getState().disconnectSocket(); } catch {}
+          try { useCommunityStore.getState().disconnectSocket(); } catch {}
           return;
         }
 
@@ -77,6 +81,8 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === "SIGNED_OUT") {
         apply(null, null);
+        try { useChatDockStore.getState().disconnectSocket(); } catch {}
+        try { useCommunityStore.getState().disconnectSocket(); } catch {}
         setLoading(false);
         return;
       }

--- a/frontend/src/pages/community/chatDock/store.ts
+++ b/frontend/src/pages/community/chatDock/store.ts
@@ -74,6 +74,7 @@ interface ChatDockState extends PersistedShape {
   updateThreadInfo: (threadId: string, patch: Partial<ChatThreadInfo>) => void;
   startDM: (otherUserId: string, seed?: ThreadSeed) => Promise<string>;
   addRecentContact: (user: { id: string; nickname?: string; avatarUrl?: string }) => void;
+  disconnectSocket: () => void;
 }
 
 /** ============ 工具/类型守卫 ============ */
@@ -282,6 +283,14 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
         });
 
         set({ socket: s });
+
+        // Disconnect on tab close
+        if (!(globalThis as any).__chatdock_unload_bound) {
+          (globalThis as any).__chatdock_unload_bound = true;
+          globalThis.addEventListener("beforeunload", () => {
+            try { get().socket?.disconnect(); } catch {}
+          });
+        }
       },
 
       /** ⭐ 幂等 + 临时线程拦截 的 joinThread */
@@ -512,6 +521,11 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
           const rest = state.recentContacts.filter((u) => u.id !== user.id);
           return { ...state, recentContacts: [user, ...rest].slice(0, 20) };
         });
+      },
+
+      disconnectSocket: () => {
+        try { get().socket?.disconnect(); } catch {}
+        set({ socket: null });
       },
     }),
     {

--- a/frontend/src/pages/community/chatDock/store.ts
+++ b/frontend/src/pages/community/chatDock/store.ts
@@ -203,7 +203,7 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
         }
 
         const envUrl = import.meta.env.VITE_SOCKET_URL as string | undefined;
-
+        const g = globalThis as Record<string, unknown>;
         let baseUrl: string | undefined;
         let pathOpt: string | undefined;
 
@@ -285,10 +285,16 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
         set({ socket: s });
 
         // Disconnect on tab close
-        if (!(globalThis as any).__chatdock_unload_bound) {
-          (globalThis as any).__chatdock_unload_bound = true;
+        if (!g.__chatdock_unload_bound) {
+          g.__chatdock_unload_bound = true;
+
           globalThis.addEventListener("beforeunload", () => {
-            try { get().socket?.disconnect(); } catch {}
+            try {
+              get().socket?.disconnect();
+            } catch (e) {
+              // 可选：记录日志，至少不让 catch 是空的
+              console.warn("[chatdock] socket disconnect on unload failed:", e);
+            }
           });
         }
       },
@@ -524,7 +530,9 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
       },
 
       disconnectSocket: () => {
-        try { get().socket?.disconnect(); } catch {}
+        try { get().socket?.disconnect(); } catch {
+          console.warn("[chatdock] socket disconnect failed");
+        }
         set({ socket: null });
       },
     }),

--- a/frontend/src/pages/community/store.ts
+++ b/frontend/src/pages/community/store.ts
@@ -78,7 +78,7 @@ interface CommunityState {
   socket: ChatSocket | null;
   currentUserId: string | null;
   setCurrentUserId: (userId: string | null) => void;
-  ensureSocket: (userId: string) => Promise<void>;
+  ensureSocket: () => Promise<void>;
   disconnectSocket: () => void;
 
   // Data actions
@@ -111,8 +111,9 @@ export const useCommunityStore = createWithEqualityFn<CommunityState>()((set, ge
   currentUserId: null,
   setCurrentUserId: (userId) => set({ currentUserId: userId }),
 
-  ensureSocket: async (userId: string) => {
+  ensureSocket: async () => {
     const existing = get().socket;
+    const g = globalThis as Record<string, unknown>;
     if (existing && existing.connected) return;
 
     const url = import.meta.env?.VITE_SOCKET_URL;
@@ -153,16 +154,24 @@ export const useCommunityStore = createWithEqualityFn<CommunityState>()((set, ge
     set({ socket: newSocket });
 
     // Disconnect on tab close
-    if (!(globalThis as any).__community_unload_bound) {
-      (globalThis as any).__community_unload_bound = true;
-      globalThis.addEventListener("beforeunload", () => {
-        try { get().socket?.disconnect(); } catch {}
-      });
-    }
+    if (!g.__chatdock_unload_bound) {
+          g.__chatdock_unload_bound = true;
+
+          globalThis.addEventListener("beforeunload", () => {
+            try {
+              get().socket?.disconnect();
+            } catch (e) {
+              // 可选：记录日志，至少不让 catch 是空的
+              console.warn("[chatdock] socket disconnect on unload failed:", e);
+            }
+          });
+        }
   },
 
   disconnectSocket: () => {
-    try { get().socket?.disconnect(); } catch {}
+    try { get().socket?.disconnect(); } catch {
+      console.warn("[chatdock] socket disconnect failed");
+    }
     set({ socket: null });
   },
 
@@ -244,7 +253,7 @@ export const useCommunityStore = createWithEqualityFn<CommunityState>()((set, ge
 
     const socket = get().socket;
     if (!socket || !socket.connected) {
-      get().ensureSocket(currentUserId);
+      get().ensureSocket();
     }
 
     const tempId = `tmp_${Date.now()}`;

--- a/frontend/src/pages/community/store.ts
+++ b/frontend/src/pages/community/store.ts
@@ -1,6 +1,7 @@
 import { createWithEqualityFn } from 'zustand/traditional'
 import { io, Socket } from "socket.io-client";
 import { api } from "./api";
+import { supabase } from "@/lib/supabase";
 
 export type TabKey = "messages" | "contacts" | "posts";
 
@@ -77,7 +78,8 @@ interface CommunityState {
   socket: ChatSocket | null;
   currentUserId: string | null;
   setCurrentUserId: (userId: string | null) => void;
-  ensureSocket: (userId: string) => void;
+  ensureSocket: (userId: string) => Promise<void>;
+  disconnectSocket: () => void;
 
   // Data actions
   fetchConversations: () => Promise<void>;
@@ -109,7 +111,7 @@ export const useCommunityStore = createWithEqualityFn<CommunityState>()((set, ge
   currentUserId: null,
   setCurrentUserId: (userId) => set({ currentUserId: userId }),
 
-  ensureSocket: (userId: string) => {
+  ensureSocket: async (userId: string) => {
     const existing = get().socket;
     if (existing && existing.connected) return;
 
@@ -119,11 +121,17 @@ export const useCommunityStore = createWithEqualityFn<CommunityState>()((set, ge
       return;
     }
 
-    // 关键修改：io() 不传泛型，用变量类型约束为 ChatSocket
+    const { data } = await supabase.auth.getSession();
+    const accessToken = data.session?.access_token;
+    if (!accessToken) {
+      console.warn("No access token; skipping socket connection");
+      return;
+    }
+
     const newSocket: ChatSocket = io(url, {
       transports: ["websocket"],
       autoConnect: true,
-      auth: { userId },
+      auth: { token: accessToken },
     });
 
     newSocket.on("connect_error", (err: Error) => {
@@ -143,6 +151,19 @@ export const useCommunityStore = createWithEqualityFn<CommunityState>()((set, ge
     });
 
     set({ socket: newSocket });
+
+    // Disconnect on tab close
+    if (!(globalThis as any).__community_unload_bound) {
+      (globalThis as any).__community_unload_bound = true;
+      globalThis.addEventListener("beforeunload", () => {
+        try { get().socket?.disconnect(); } catch {}
+      });
+    }
+  },
+
+  disconnectSocket: () => {
+    try { get().socket?.disconnect(); } catch {}
+    set({ socket: null });
   },
 
   fetchConversations: async () => {

--- a/frontend/src/pages/user/dashboard/UserHeader.tsx
+++ b/frontend/src/pages/user/dashboard/UserHeader.tsx
@@ -10,6 +10,8 @@ import { logout } from "@/api/auth";
 import { useUser } from "@/contexts/UserContext";
 import { supabase } from "@/lib/supabase";
 import { useNavigate } from "react-router-dom";
+import { useChatDockStore } from "@/pages/community/chatDock/store";
+import { useCommunityStore } from "@/pages/community/store";
 
 interface UserHeaderProps {
   username?: string;
@@ -20,6 +22,8 @@ export function UserHeader({ username = "Alex", avatarUrl }: UserHeaderProps) {
   const [logoutOpen, setLogoutOpen] = useState(false);
   const { setUser } = useUser();       // 这里 user/loading 不一定要用到
   const navigate = useNavigate();
+  const disconnectChatDock = useChatDockStore((s) => s.disconnectSocket);
+  const disconnectCommunity = useCommunityStore((s) => s.disconnectSocket);
 
   return (
     <>
@@ -71,6 +75,8 @@ export function UserHeader({ username = "Alex", avatarUrl }: UserHeaderProps) {
                 onClick={async () => {
                   try { await supabase.auth.signOut(); } catch {}
                   try { await logout(); } catch {}
+                  try { disconnectChatDock(); } catch {}
+                  try { disconnectCommunity(); } catch {}
                   setUser(null);
                   setLogoutOpen(false);
                   navigate("/login", { replace: true });


### PR DESCRIPTION
Enforce token-based socket authentication and disconnect sockets on logout or tab close.

Previously, sockets could remain connected after logout due to a server-side `userId` fallback and missing frontend disconnect logic, leading to persistent 'logged-in' states.

---
<a href="https://cursor.com/background-agent?bcId=bc-7acb3c6b-2863-4165-b4ee-eb433f839934">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7acb3c6b-2863-4165-b4ee-eb433f839934">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

