### PR TITLE
Revamp user search dock to recent contacts dock

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,2 @@
+export $(grep -v '^#' ../../.env | xargs)
+./mvnw spring-boot:run

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,9 @@ import ChatPage from './pages/ChatPage';
 import RequireAuth from "./components/RequireAuth";
 import { UserProvider } from "./contexts/UserContext";
 import CoachApplicationForm from "./pages/coach/CoachApplicationForm";
+import CoachDashboard from './pages/coach/CoachDashboard';
+import SportEditor from './pages/coach/SportEditor';
+import CourseEditor from './pages/coach/CourseEditor';
 
 
 //console.log("Rendering App...");
@@ -42,8 +45,12 @@ function App() {
           
         </Route>
 
-        <Route element={<RequireAuth requireProfile = {false}/>}>
+        <Route element={<RequireAuth requireProfile = {false}/>}> 
           <Route path="/coach-application" element={<CoachApplicationForm />}/>
+          <Route path="/coach" element={<CoachDashboard />} />
+          <Route path="/coach/sports/new" element={<SportEditor />} />
+          <Route path="/coach/sports/:id/edit" element={<SportEditor />} />
+          <Route path="/coach/sports/:id/course" element={<CourseEditor />} />
         </Route>
       </Routes>
     </UserProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,9 +14,10 @@ import CommunityPage from './pages/community/CommunityPage';
 import RequireAuth from "./components/RequireAuth";
 import { UserProvider } from "./contexts/UserContext";
 import CoachApplicationForm from "./pages/coach/CoachApplicationForm";
+import CoachDashboard from './pages/coach/CoachDashboard';
+import SportEditor from './pages/coach/SportEditor';
+import CourseEditor from './pages/coach/CourseEditor';
 import ChatDock from "./pages/community/chatDock/ChatDock";
-
-
 //console.log("Rendering App...");
 
 function App() {
@@ -46,7 +47,15 @@ function App() {
             <Route index element={<ProfilePage />} />
             <Route path="profile" element={<ProfilePage />} />
           </Route>
+          
+        </Route>
+
+        <Route element={<RequireAuth requireProfile = {false}/>}>
           <Route path="/coach-application" element={<CoachApplicationForm />}/>
+          <Route path="/coach" element={<CoachDashboard />} />
+          <Route path="/coach/sports/new" element={<SportEditor />} />
+          <Route path="/coach/sports/:id/edit" element={<SportEditor />} />
+          <Route path="/coach/sports/:id/course" element={<CourseEditor />} />
         </Route>
       </Routes>
       {/* Globally mounted Chat Dock (desktop-only) */}

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -42,3 +42,8 @@ export async function getThreadMessages(
   );
   return res.data.messages;
 }
+
+export async function listThreads() {
+  const res = await api.get<{ threads: ChatThreadSummary[] }>(`/chat/threads`);
+  return res.data.threads;
+}

--- a/frontend/src/components/form/Input.tsx
+++ b/frontend/src/components/form/Input.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react'
+import type { RefCallback } from 'react'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+
+/** ================== Shared Types ================== */
+/** 把 RHF 的 field 形状抽象出来，避免强绑定 RHF 版本 */
+export type RHFFieldBase<T extends HTMLElement = HTMLInputElement> = {
+  value: unknown
+  onChange: (v: unknown) => void
+  onBlur: () => void
+  name: string
+  ref: RefCallback<T>
+}
+
+/** 工具：收敛成 DOM 可接受的 string 值 */
+function toStringValue(v: unknown): string {
+  if (v == null) return ''
+  return typeof v === 'string' ? v : String(v)
+}
+
+/** ================== Text / String Input ================== */
+export type RHFStringInputProps = Omit<
+  React.ComponentProps<typeof Input>,
+  'value' | 'onChange' | 'name' | 'ref' | 'onBlur'
+> & {
+  field: RHFFieldBase<HTMLInputElement>
+}
+
+/** 安全的文本输入适配器（解决 field.value 是联合类型时的 DOM value 类型报错） */
+export function RHFStringInput({ field, ...rest }: RHFStringInputProps) {
+  return (
+    <Input
+      {...rest}
+      name={field.name}
+      ref={field.ref}
+      onBlur={field.onBlur}
+      value={toStringValue(field.value)}
+      onChange={(e) => field.onChange(e.target.value)}
+    />
+  )
+}
+
+/** ================== Textarea ================== */
+export type RHFTextareaProps = Omit<
+  React.ComponentProps<typeof Textarea>,
+  'value' | 'onChange' | 'name' | 'ref' | 'onBlur'
+> & {
+  field: RHFFieldBase<HTMLTextAreaElement>
+}
+
+/** 安全的多行文本输入适配器 */
+export function RHFTextarea({ field, ...rest }: RHFTextareaProps) {
+  return (
+    <Textarea
+      {...rest}
+      name={field.name}
+      ref={field.ref}
+      onBlur={field.onBlur}
+      value={toStringValue(field.value)}
+      onChange={(e) => field.onChange(e.target.value)}
+    />
+  )
+}
+
+/** ================== Number Input ================== */
+/**
+ * 一个安全的数字输入适配器：
+ * - 将 field.value: unknown 缩到 DOM 可接受的类型（string | number | undefined）
+ * - onChange：'' → ''（受控空）；否则 Number(raw)
+ * - 可选 preParse：比如去掉千分位、货币符号等
+ * - 完全沿用项目的 <Input> 外观
+ */
+export type RHFNumberInputProps = Omit<
+  React.ComponentProps<typeof Input>,
+  'value' | 'onChange' | 'type' | 'defaultValue' | 'name' | 'ref' | 'onBlur'
+> & {
+  /** RHF render={({ field }) => ...} 里传进来的 field */
+  field: RHFFieldBase<HTMLInputElement>
+  /**
+   * 允许输入为空（空串）。默认 true：
+   * - true：空串保持为 ''，不转数字
+   * - false：空串当作 0
+   */
+  allowEmpty?: boolean
+  /** 将输入映射为 number 前的自定义清洗（可选） */
+  preParse?: (raw: string) => string
+}
+
+export function RHFNumberInput({
+  field,
+  allowEmpty = true,
+  preParse,
+  step,
+  ...rest
+}: RHFNumberInputProps) {
+  const domValue =
+    field.value === undefined || field.value === null
+      ? ''
+      : typeof field.value === 'number'
+        ? (Number.isFinite(field.value) ? field.value : '')
+        : String(field.value)
+
+  return (
+    <Input
+      {...rest}
+      type="number"
+      step={step}
+      name={field.name}
+      ref={field.ref}
+      onBlur={field.onBlur}
+      value={domValue}
+      onChange={(e) => {
+        let raw = e.target.value
+        if (preParse) raw = preParse(raw)
+        if (raw === '') {
+          field.onChange(allowEmpty ? '' : 0)
+          return
+        }
+        // 不用 valueAsNumber，避免 NaN 干扰
+        const n = Number(raw)
+        field.onChange(Number.isNaN(n) ? '' : n)
+      }}
+    />
+  )
+}
+
+
+export function RHFSelectString({
+  field,
+  options,
+  onChange, // 可选地透传外部回调
+  getValue, // 当 Combobox onChange 返回对象时如何取值
+  ...rest
+}: {
+  field: RHFFieldBase<HTMLInputElement>
+  options: Array<{ value: string; label: string }>
+  onChange?: (v: string) => void
+  getValue?: (arg: unknown) => string | undefined
+} & Omit<React.ComponentProps<any>, 'value' | 'onChange'>) {
+  const value = typeof field.value === 'string' ? field.value : ''
+  const handleChange = (arg: unknown) => {
+    const v = (typeof arg === 'string'
+      ? arg
+      : (rest as any).value !== undefined
+      ? String((rest as any).value)
+      : undefined) ?? (getValue ? getValue(arg) : (arg as any)?.value)
+    const next = v ?? ''
+    field.onChange(next)
+    onChange?.(next)
+  }
+  const Cmb = (rest as any).as || (rest as any).component || (rest as any).Combobox || (rest as any)
+  return (
+    <Cmb
+      {...rest}
+      options={options}
+      value={value}
+      onChange={handleChange}
+    />
+  )
+}

--- a/frontend/src/lib/avatar.ts
+++ b/frontend/src/lib/avatar.ts
@@ -1,0 +1,15 @@
+// Simple helper to generate a public avatar URL from Supabase storage
+// Assumes a public bucket named "avatars" and each file named by userId
+import { supabase } from "./supabase";
+
+export function getAvatarPublicUrl(userId: string | undefined | null): string | undefined {
+  if (!userId) return undefined;
+  try {
+    const { data } = supabase.storage.from("avatars").getPublicUrl(String(userId));
+    const url = data?.publicUrl;
+    return typeof url === "string" && url.length > 0 ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -57,7 +57,7 @@ export default function HomePage() {
                   <DropdownMenuItem onClick={() => navigate("/dashboard")}>
                     Personal Dashboard
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => navigate("/become-coach")}>
+                  <DropdownMenuItem onClick={() => navigate("/coach-application")}>
                     Become a Coach
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => navigate("/manage-venue")}>

--- a/frontend/src/pages/coach/CoachDashboard.tsx
+++ b/frontend/src/pages/coach/CoachDashboard.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { supabase } from '@/lib/supabase'
+import { useUser } from '@/contexts/UserContext'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+type CoachSport = {
+  id: string
+  coach_id: string
+  sport_id: string
+  self_intro: string | null
+  experience_years: string | null
+  has_certificate: boolean | null
+  certificate_type: string | null
+  certificate_url: string | null
+  status: 'pending' | 'approved' | 'rejected'
+  created_at: string
+  updated_at: string
+}
+
+type Sport = { id: string; name: string }
+type CourseDetail = {
+  id: string
+  coach_sport_id: string
+  training_modes: string[] | null
+  available_time_slots: string[] | null
+  preferred_frequency: string | null
+  training_goals: string[] | null
+}
+
+type CoachPackagePrice = {
+  id: string
+  coach_sport_id: string
+  lessons_count: number
+  lesson_duration_minutes: number
+  price: number
+}
+
+type CoachMedia = {
+  coach_sport_id: string
+  type: 'image' | 'video' | 'other'
+  url: string
+  description: string | null
+}
+
+export default function CoachDashboard() {
+  const { user, loading: loadingUser } = useUser()
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [coachSports, setCoachSports] = useState<CoachSport[]>([])
+  const [sportsMap, setSportsMap] = useState<Record<string, Sport>>({})
+  const [courseByCoachSport, setCourseByCoachSport] = useState<Record<string, CourseDetail | undefined>>({})
+  const [packagesByCoachSport, setPackagesByCoachSport] = useState<Record<string, CoachPackagePrice[]>>({})
+  const [mediaByCoachSport, setMediaByCoachSport] = useState<Record<string, CoachMedia | undefined>>({})
+
+  useEffect(() => {
+    if (loadingUser) return
+    if (!user) {
+      navigate('/login')
+      return
+    }
+    const run = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const { data: coachSportsData, error: csErr } = await supabase
+          .from('coach_sports')
+          .select('*')
+          .eq('coach_id', user.id)
+          .order('created_at', { ascending: false })
+        if (csErr) throw csErr
+        const sportsIds = Array.from(new Set((coachSportsData ?? []).map(s => s.sport_id)))
+        const coachSportIds = Array.from(new Set((coachSportsData ?? []).map(s => s.id)))
+
+        const [sportsRes, courseRes, pkgRes, mediaRes] = await Promise.all([
+          sportsIds.length
+            ? supabase.from('sports').select('id,name').in('id', sportsIds)
+            : Promise.resolve({ data: [] as Sport[], error: null } as any),
+          coachSportIds.length
+            ? supabase.from('course_detail').select('*').in('coach_sport_id', coachSportIds)
+            : Promise.resolve({ data: [] as CourseDetail[], error: null } as any),
+          coachSportIds.length
+            ? supabase.from('coach_package_prices').select('*').in('coach_sport_id', coachSportIds)
+            : Promise.resolve({ data: [] as CoachPackagePrice[], error: null } as any),
+          coachSportIds.length
+            ? supabase.from('coach_media').select('*').in('coach_sport_id', coachSportIds)
+            : Promise.resolve({ data: [] as CoachMedia[], error: null } as any),
+        ])
+
+        if (sportsRes.error) throw sportsRes.error
+        if (courseRes.error) throw courseRes.error
+        if (pkgRes.error) throw pkgRes.error
+        if (mediaRes.error) throw mediaRes.error
+
+        const sportsMapNext: Record<string, Sport> = {}
+        for (const s of (sportsRes.data ?? []) as Sport[]) sportsMapNext[s.id] = s
+
+        const courseMapNext: Record<string, CourseDetail> = {}
+        for (const c of (courseRes.data ?? []) as CourseDetail[]) courseMapNext[c.coach_sport_id] = c
+
+        const packagesMapNext: Record<string, CoachPackagePrice[]> = {}
+        for (const p of (pkgRes.data ?? []) as CoachPackagePrice[]) {
+          const key = p.coach_sport_id
+          if (!packagesMapNext[key]) packagesMapNext[key] = []
+          packagesMapNext[key].push(p)
+        }
+
+        const mediaMapNext: Record<string, CoachMedia> = {}
+        for (const m of (mediaRes.data ?? []) as CoachMedia[]) mediaMapNext[m.coach_sport_id] = m
+
+        setCoachSports((coachSportsData ?? []) as CoachSport[])
+        setSportsMap(sportsMapNext)
+        setCourseByCoachSport(courseMapNext)
+        setPackagesByCoachSport(packagesMapNext)
+        setMediaByCoachSport(mediaMapNext)
+      } catch (e: any) {
+        setError(e.message || 'Failed to load coach data')
+      } finally {
+        setLoading(false)
+      }
+    }
+    run()
+  }, [user, loadingUser, navigate])
+
+  if (loadingUser || loading) return <div className="p-6">Loading…</div>
+  if (error) return (
+    <div className="p-6 text-red-600">
+      {error}
+      <div className="mt-4">
+        <Button onClick={() => window.location.reload()}>Reload</Button>
+      </div>
+    </div>
+  )
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-semibold">Coach Center</h2>
+        <div className="flex gap-3">
+          <Link to="/coach/sports/new">
+            <Button>Create profile</Button>
+          </Link>
+        </div>
+      </div>
+
+      {coachSports.length === 0 ? (
+        <div className="text-muted-foreground">No coach profiles yet. Create one to get started.</div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {coachSports.map((cs) => {
+            const sport = sportsMap[cs.sport_id]
+            const course = courseByCoachSport[cs.id]
+            const pkgCount = (packagesByCoachSport[cs.id] || []).length
+            const hasMedia = !!mediaByCoachSport[cs.id]
+            return (
+              <Card key={cs.id} className="border">
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between">
+                    <span>{sport?.name || 'Unknown sport'}</span>
+                    <span className="text-sm px-2 py-0.5 rounded bg-gray-100 text-gray-700 capitalize">{cs.status}</span>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div>
+                    <div className="text-sm text-muted-foreground">Experience</div>
+                    <div className="text-sm">{cs.experience_years || '-'}</div>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2 text-sm">
+                    <div>
+                      <div className="text-muted-foreground">Course</div>
+                      <div>{course ? 'Configured' : 'Missing'}</div>
+                    </div>
+                    <div>
+                      <div className="text-muted-foreground">Packages</div>
+                      <div>{pkgCount}</div>
+                    </div>
+                    <div>
+                      <div className="text-muted-foreground">Media</div>
+                      <div>{hasMedia ? 1 : 0}</div>
+                    </div>
+                  </div>
+                  <div className="flex gap-2 pt-2">
+                    <Button variant="outline" onClick={() => navigate(`/coach/sports/${cs.id}/edit`)}>Edit</Button>
+                    <Button onClick={() => navigate(`/coach/sports/${cs.id}/course`)}>Course & Packages</Button>
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/frontend/src/pages/coach/CourseEditor.tsx
+++ b/frontend/src/pages/coach/CourseEditor.tsx
@@ -15,6 +15,7 @@ const modes = ['1v1','1v2','Group','Online'] as const
 const timeSlots = ['Weekdays Morning','Weekdays Afternoon','Weekdays Evening','Weekend Morning','Weekend Afternoon','Weekend Evening'] as const
 const goals = ['Skill Improvement','Competition','Build Interest','Well-being'] as const
 const frequencies = ['1–2 per week','3+ per week','Flexible'] as const
+import { RHFNumberInput } from '@/components/form/Input'
 
 const schema = z.object({
   training_modes: z.array(z.string()).default([]),
@@ -31,13 +32,15 @@ const schema = z.object({
       lesson_duration_minutes: z.coerce.number().int().positive(),
       price: z.coerce.number().positive(),
     })
-  ),
+  ).default([]), // 👈 建议给 packages 也加默认空数组，更稳
   media_file: z.any().optional(),
   media_type: z.enum(['image','video','other']).default('image'),
   media_description: z.string().optional(),
 })
 
-type FormValues = z.infer<typeof schema>
+// 👈 关键改动：区分输入/输出类型
+type FormInput = z.input<typeof schema>    // 允许 undefined / 原始输入
+type FormValues = z.output<typeof schema>  // 已应用 default/coerce 后的最终类型
 
 export default function CourseEditor() {
   const { id: coachSportId } = useParams()
@@ -48,8 +51,10 @@ export default function CourseEditor() {
   const [existingCourseId, setExistingCourseId] = useState<string | null>(null)
   const [signedMediaUrl, setSignedMediaUrl] = useState<string | null>(null)
 
-  const form = useForm<FormValues>({
+  // 👈 关键改动：useForm 使用三泛型 <FormInput, any, FormValues>
+  const form = useForm<FormInput, any, FormValues>({
     resolver: zodResolver(schema),
+    // defaultValues 是 DeepPartial<FormInput>，保持输入侧形状（允许 undefined）
     defaultValues: {
       training_modes: [],
       available_time_slots: [],
@@ -63,7 +68,8 @@ export default function CourseEditor() {
     },
   })
 
-  const packagesField = useFieldArray({ control: form.control, name: 'packages' })
+  // 👈 建议为 useFieldArray 指定 TFieldValues（即 FormInput）
+  const packagesField = useFieldArray<FormInput>({ control: form.control, name: 'packages' as const })
 
   useEffect(() => {
     if (!coachSportId) return
@@ -78,11 +84,12 @@ export default function CourseEditor() {
         if (cErr) throw cErr
         if (course) {
           setExistingCourseId(course.id)
+          // 👈 reset 接受输入侧形状（允许 undefined）
           form.reset({
-            training_modes: course.training_modes || [],
-            available_time_slots: course.available_time_slots || [],
-            preferred_frequency: course.preferred_frequency || undefined,
-            training_goals: course.training_goals || [],
+            training_modes: course.training_modes ?? [],
+            available_time_slots: course.available_time_slots ?? [],
+            preferred_frequency: course.preferred_frequency ?? undefined,
+            training_goals: course.training_goals ?? [],
             attributes_style: [],
             attributes_prefer: [],
             attributes_not_prefer: [],
@@ -136,6 +143,7 @@ export default function CourseEditor() {
     run()
   }, [coachSportId])
 
+  // 👈 这里的 values 使用 FormValues（输出类型），跟 resolver 的输出一致
   const saveAll = async (values: FormValues) => {
     if (!coachSportId || !user) return
     setSaving(true)
@@ -245,10 +253,19 @@ export default function CourseEditor() {
 
   if (loading) return <div className="p-6">Loading…</div>
 
+  // 👇 读取 watch 的地方都加了 ?? [] 兜底，避免输入侧 undefined 的类型告警
+  const watchTrainingModes = form.watch('training_modes') ?? []
+  const watchTimeSlots = form.watch('available_time_slots') ?? []
+  const watchGoals = form.watch('training_goals') ?? []
+  const watchStyle = form.watch('attributes_style') ?? []
+  const watchPrefer = form.watch('attributes_prefer') ?? []
+  const watchNotPrefer = form.watch('attributes_not_prefer') ?? []
+
   return (
     <div className="max-w-3xl mx-auto p-6">
       <h2 className="text-xl font-semibold mb-4">Course, Attributes, Prices & Media</h2>
       <Form {...form}>
+        {/* 👈 handleSubmit 现在会把 FormValues（输出类型）传进 saveAll，类型不再报错 */}
         <form onSubmit={form.handleSubmit(saveAll)} className="space-y-8">
           <section className="space-y-3">
             <h3 className="font-medium">Training modes</h3>
@@ -256,9 +273,9 @@ export default function CourseEditor() {
               {modes.map((m) => (
                 <label key={m} className="flex items-center gap-2 text-sm">
                   <Checkbox
-                    checked={form.watch('training_modes').includes(m)}
+                    checked={watchTrainingModes.includes(m)}
                     onCheckedChange={(checked) => {
-                      const cur = new Set(form.getValues('training_modes'))
+                      const cur = new Set(form.getValues('training_modes') ?? [])
                       if (checked) cur.add(m)
                       else cur.delete(m)
                       form.setValue('training_modes', Array.from(cur))
@@ -276,9 +293,9 @@ export default function CourseEditor() {
               {timeSlots.map((t) => (
                 <label key={t} className="flex items-center gap-2 text-sm">
                   <Checkbox
-                    checked={form.watch('available_time_slots').includes(t)}
+                    checked={watchTimeSlots.includes(t)}
                     onCheckedChange={(checked) => {
-                      const cur = new Set(form.getValues('available_time_slots'))
+                      const cur = new Set(form.getValues('available_time_slots') ?? [])
                       if (checked) cur.add(t)
                       else cur.delete(t)
                       form.setValue('available_time_slots', Array.from(cur))
@@ -315,9 +332,9 @@ export default function CourseEditor() {
               {goals.map((g) => (
                 <label key={g} className="flex items-center gap-2 text-sm">
                   <Checkbox
-                    checked={form.watch('training_goals').includes(g)}
+                    checked={watchGoals.includes(g)}
                     onCheckedChange={(checked) => {
-                      const cur = new Set(form.getValues('training_goals'))
+                      const cur = new Set(form.getValues('training_goals') ?? [])
                       if (checked) cur.add(g)
                       else cur.delete(g)
                       form.setValue('training_goals', Array.from(cur))
@@ -334,15 +351,15 @@ export default function CourseEditor() {
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
                 <div className="text-sm mb-1">Style</div>
-                <Textarea value={form.watch('attributes_style').join('\n')} onChange={(e) => form.setValue('attributes_style', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
+                <Textarea value={watchStyle.join('\n')} onChange={(e) => form.setValue('attributes_style', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
               </div>
               <div>
                 <div className="text-sm mb-1">Prefer student</div>
-                <Textarea value={form.watch('attributes_prefer').join('\n')} onChange={(e) => form.setValue('attributes_prefer', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
+                <Textarea value={watchPrefer.join('\n')} onChange={(e) => form.setValue('attributes_prefer', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
               </div>
               <div>
                 <div className="text-sm mb-1">Not prefer student</div>
-                <Textarea value={form.watch('attributes_not_prefer').join('\n')} onChange={(e) => form.setValue('attributes_not_prefer', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
+                <Textarea value={watchNotPrefer.join('\n')} onChange={(e) => form.setValue('attributes_not_prefer', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
               </div>
             </div>
           </section>
@@ -358,7 +375,7 @@ export default function CourseEditor() {
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>Lessons</FormLabel>
-                        <Input type="number" {...field} />
+                        <RHFNumberInput field={field} />
                         <FormMessage />
                       </FormItem>
                     )}
@@ -369,7 +386,7 @@ export default function CourseEditor() {
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>Duration (min)</FormLabel>
-                        <Input type="number" {...field} />
+                        <RHFNumberInput field={field} />
                         <FormMessage />
                       </FormItem>
                     )}
@@ -380,7 +397,7 @@ export default function CourseEditor() {
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>Price</FormLabel>
-                        <Input type="number" step="0.01" {...field} />
+                        <RHFNumberInput field={field} step="0.01" />
                         <FormMessage />
                       </FormItem>
                     )}
@@ -447,4 +464,3 @@ export default function CourseEditor() {
     </div>
   )
 }
-

--- a/frontend/src/pages/coach/CourseEditor.tsx
+++ b/frontend/src/pages/coach/CourseEditor.tsx
@@ -1,0 +1,466 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useForm, useFieldArray } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { supabase } from '@/lib/supabase'
+import { useUser } from '@/contexts/UserContext'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
+
+const modes = ['1v1','1v2','Group','Online'] as const
+const timeSlots = ['Weekdays Morning','Weekdays Afternoon','Weekdays Evening','Weekend Morning','Weekend Afternoon','Weekend Evening'] as const
+const goals = ['Skill Improvement','Competition','Build Interest','Well-being'] as const
+const frequencies = ['1–2 per week','3+ per week','Flexible'] as const
+import { RHFNumberInput } from '@/components/form/Input'
+
+const schema = z.object({
+  training_modes: z.array(z.string()).default([]),
+  available_time_slots: z.array(z.string()).default([]),
+  preferred_frequency: z.string().nullable().optional(),
+  training_goals: z.array(z.string()).default([]),
+  attributes_style: z.array(z.string()).default([]),
+  attributes_prefer: z.array(z.string()).default([]),
+  attributes_not_prefer: z.array(z.string()).default([]),
+  packages: z.array(
+    z.object({
+      id: z.string().optional(),
+      lessons_count: z.coerce.number().int().positive(),
+      lesson_duration_minutes: z.coerce.number().int().positive(),
+      price: z.coerce.number().positive(),
+    })
+  ).default([]), // 👈 建议给 packages 也加默认空数组，更稳
+  media_file: z.any().optional(),
+  media_type: z.enum(['image','video','other']).default('image'),
+  media_description: z.string().optional(),
+})
+
+// 👈 关键改动：区分输入/输出类型
+type FormInput = z.input<typeof schema>    // 允许 undefined / 原始输入
+type FormValues = z.output<typeof schema>  // 已应用 default/coerce 后的最终类型
+
+export default function CourseEditor() {
+  const { id: coachSportId } = useParams()
+  const { user } = useUser()
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [existingCourseId, setExistingCourseId] = useState<string | null>(null)
+  const [signedMediaUrl, setSignedMediaUrl] = useState<string | null>(null)
+
+  // 👈 关键改动：useForm 使用三泛型 <FormInput, any, FormValues>
+  const form = useForm<FormInput, any, FormValues>({
+    resolver: zodResolver(schema),
+    // defaultValues 是 DeepPartial<FormInput>，保持输入侧形状（允许 undefined）
+    defaultValues: {
+      training_modes: [],
+      available_time_slots: [],
+      preferred_frequency: undefined,
+      training_goals: [],
+      attributes_style: [],
+      attributes_prefer: [],
+      attributes_not_prefer: [],
+      packages: [],
+      media_type: 'image',
+    },
+  })
+
+  // 👈 建议为 useFieldArray 指定 TFieldValues（即 FormInput）
+  const packagesField = useFieldArray<FormInput>({ control: form.control, name: 'packages' as const })
+
+  useEffect(() => {
+    if (!coachSportId) return
+    const run = async () => {
+      setLoading(true)
+      try {
+        const { data: course, error: cErr } = await supabase
+          .from('course_detail')
+          .select('*')
+          .eq('coach_sport_id', coachSportId)
+          .maybeSingle()
+        if (cErr) throw cErr
+        if (course) {
+          setExistingCourseId(course.id)
+          // 👈 reset 接受输入侧形状（允许 undefined）
+          form.reset({
+            training_modes: course.training_modes ?? [],
+            available_time_slots: course.available_time_slots ?? [],
+            preferred_frequency: course.preferred_frequency ?? undefined,
+            training_goals: course.training_goals ?? [],
+            attributes_style: [],
+            attributes_prefer: [],
+            attributes_not_prefer: [],
+            packages: [],
+            media_type: 'image',
+          })
+        }
+
+        const { data: attrs } = await supabase
+          .from('course_attributes')
+          .select('*')
+          .eq('course_id', course?.id || '')
+
+        if (attrs && attrs.length) {
+          form.setValue('attributes_style', attrs.filter(a => a.type === 'style').map(a => a.value))
+          form.setValue('attributes_prefer', attrs.filter(a => a.type === 'prefer_student').map(a => a.value))
+          form.setValue('attributes_not_prefer', attrs.filter(a => a.type === 'not_prefer_student').map(a => a.value))
+        }
+
+        const { data: pkgs } = await supabase
+          .from('coach_package_prices')
+          .select('*')
+          .eq('coach_sport_id', coachSportId)
+          .order('lessons_count')
+        if (pkgs) {
+          packagesField.replace(
+            pkgs.map((p: any) => ({
+              id: p.id,
+              lessons_count: p.lessons_count,
+              lesson_duration_minutes: p.lesson_duration_minutes,
+              price: Number(p.price),
+            }))
+          )
+        }
+
+        const { data: media } = await supabase
+          .from('coach_media')
+          .select('*')
+          .eq('coach_sport_id', coachSportId)
+          .maybeSingle()
+        if (media?.url) {
+          const { data: signed } = await supabase.storage
+            .from('coach-media')
+            .createSignedUrl(media.url, 3600)
+          if (signed?.signedUrl) setSignedMediaUrl(signed.signedUrl)
+        }
+      } finally {
+        setLoading(false)
+      }
+    }
+    run()
+  }, [coachSportId])
+
+  // 👈 这里的 values 使用 FormValues（输出类型），跟 resolver 的输出一致
+  const saveAll = async (values: FormValues) => {
+    if (!coachSportId || !user) return
+    setSaving(true)
+    try {
+      // upsert course_detail
+      let courseId = existingCourseId
+      if (!courseId) {
+        const { data, error } = await supabase
+          .from('course_detail')
+          .insert({
+            coach_sport_id: coachSportId,
+            training_modes: values.training_modes,
+            available_time_slots: values.available_time_slots,
+            preferred_frequency: values.preferred_frequency || null,
+            training_goals: values.training_goals,
+          })
+          .select('id')
+          .single()
+        if (error) throw error
+        courseId = data.id
+        setExistingCourseId(courseId)
+      } else {
+        const { error } = await supabase
+          .from('course_detail')
+          .update({
+            training_modes: values.training_modes,
+            available_time_slots: values.available_time_slots,
+            preferred_frequency: values.preferred_frequency || null,
+            training_goals: values.training_goals,
+          })
+          .eq('id', courseId)
+        if (error) throw error
+      }
+
+      // replace attributes
+      if (courseId) {
+        await supabase.from('course_attributes').delete().eq('course_id', courseId)
+        const rows: any[] = []
+        values.attributes_style.forEach(v => rows.push({ course_id: courseId, type: 'style', value: v }))
+        values.attributes_prefer.forEach(v => rows.push({ course_id: courseId, type: 'prefer_student', value: v }))
+        values.attributes_not_prefer.forEach(v => rows.push({ course_id: courseId, type: 'not_prefer_student', value: v }))
+        if (rows.length) await supabase.from('course_attributes').insert(rows)
+      }
+
+      // upsert packages
+      const { data: existingPkgs } = await supabase
+        .from('coach_package_prices')
+        .select('id')
+        .eq('coach_sport_id', coachSportId)
+      const existingIds = new Set((existingPkgs || []).map((p: any) => p.id))
+      const newRows = values.packages.filter(p => !p.id).map(p => ({
+        coach_sport_id: coachSportId,
+        lessons_count: p.lessons_count,
+        lesson_duration_minutes: p.lesson_duration_minutes,
+        price: p.price,
+      }))
+      if (newRows.length) await supabase.from('coach_package_prices').insert(newRows)
+      const updateRows = values.packages.filter(p => p.id)
+      for (const p of updateRows) {
+        await supabase
+          .from('coach_package_prices')
+          .update({ lessons_count: p.lessons_count, lesson_duration_minutes: p.lesson_duration_minutes, price: p.price })
+          .eq('id', p.id)
+      }
+      // delete removed
+      const keepIds = new Set(values.packages.filter(p => p.id).map(p => p.id as string))
+      for (const id of existingIds) {
+        if (!keepIds.has(id)) {
+          await supabase.from('coach_package_prices').delete().eq('id', id)
+        }
+      }
+
+      // handle media upload (single row due to PK constraint)
+      const file: File | undefined = (values as any).media_file?.[0]
+      if (file) {
+        const path = `${user.id}/${coachSportId}/${crypto.randomUUID()}-${file.name}`
+        const up = await supabase.storage.from('coach-media').upload(path, file, { upsert: false })
+        if (up.error) throw up.error
+        await supabase
+          .from('coach_media')
+          .upsert({
+            coach_sport_id: coachSportId,
+            coach_id: user.profile?.id || user.id,
+            type: values.media_type,
+            url: up.data.path,
+            description: values.media_description || null,
+          })
+        const { data: signed } = await supabase.storage.from('coach-media').createSignedUrl(path, 3600)
+        if (signed?.signedUrl) setSignedMediaUrl(signed.signedUrl)
+      }
+
+      navigate('/coach')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const deleteMedia = async () => {
+    if (!coachSportId) return
+    const { data: media } = await supabase.from('coach_media').select('*').eq('coach_sport_id', coachSportId).maybeSingle()
+    if (media?.url) {
+      await supabase.storage.from('coach-media').remove([media.url])
+    }
+    await supabase.from('coach_media').delete().eq('coach_sport_id', coachSportId)
+    setSignedMediaUrl(null)
+  }
+
+  if (loading) return <div className="p-6">Loading…</div>
+
+  // 👇 读取 watch 的地方都加了 ?? [] 兜底，避免输入侧 undefined 的类型告警
+  const watchTrainingModes = form.watch('training_modes') ?? []
+  const watchTimeSlots = form.watch('available_time_slots') ?? []
+  const watchGoals = form.watch('training_goals') ?? []
+  const watchStyle = form.watch('attributes_style') ?? []
+  const watchPrefer = form.watch('attributes_prefer') ?? []
+  const watchNotPrefer = form.watch('attributes_not_prefer') ?? []
+
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <h2 className="text-xl font-semibold mb-4">Course, Attributes, Prices & Media</h2>
+      <Form {...form}>
+        {/* 👈 handleSubmit 现在会把 FormValues（输出类型）传进 saveAll，类型不再报错 */}
+        <form onSubmit={form.handleSubmit(saveAll)} className="space-y-8">
+          <section className="space-y-3">
+            <h3 className="font-medium">Training modes</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+              {modes.map((m) => (
+                <label key={m} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={watchTrainingModes.includes(m)}
+                    onCheckedChange={(checked) => {
+                      const cur = new Set(form.getValues('training_modes') ?? [])
+                      if (checked) cur.add(m)
+                      else cur.delete(m)
+                      form.setValue('training_modes', Array.from(cur))
+                    }}
+                  />
+                  {m}
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Available time slots</h3>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+              {timeSlots.map((t) => (
+                <label key={t} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={watchTimeSlots.includes(t)}
+                    onCheckedChange={(checked) => {
+                      const cur = new Set(form.getValues('available_time_slots') ?? [])
+                      if (checked) cur.add(t)
+                      else cur.delete(t)
+                      form.setValue('available_time_slots', Array.from(cur))
+                    }}
+                  />
+                  {t}
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Preferred frequency</h3>
+            <div className="flex flex-wrap gap-2 text-sm">
+              {frequencies.map((f) => {
+                const selected = form.watch('preferred_frequency') === f
+                return (
+                  <button
+                    type="button"
+                    key={f}
+                    className={`px-3 py-1 rounded border ${selected ? 'bg-black text-white' : ''}`}
+                    onClick={() => form.setValue('preferred_frequency', selected ? undefined : f)}
+                  >
+                    {f}
+                  </button>
+                )
+              })}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Training goals</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+              {goals.map((g) => (
+                <label key={g} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={watchGoals.includes(g)}
+                    onCheckedChange={(checked) => {
+                      const cur = new Set(form.getValues('training_goals') ?? [])
+                      if (checked) cur.add(g)
+                      else cur.delete(g)
+                      form.setValue('training_goals', Array.from(cur))
+                    }}
+                  />
+                  {g}
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Attributes</h3>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <div className="text-sm mb-1">Style</div>
+                <Textarea value={watchStyle.join('\n')} onChange={(e) => form.setValue('attributes_style', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
+              </div>
+              <div>
+                <div className="text-sm mb-1">Prefer student</div>
+                <Textarea value={watchPrefer.join('\n')} onChange={(e) => form.setValue('attributes_prefer', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
+              </div>
+              <div>
+                <div className="text-sm mb-1">Not prefer student</div>
+                <Textarea value={watchNotPrefer.join('\n')} onChange={(e) => form.setValue('attributes_not_prefer', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Packages</h3>
+            <div className="space-y-3">
+              {packagesField.fields.map((field, idx) => (
+                <div key={field.id} className="grid grid-cols-4 gap-3 items-end">
+                  <FormField
+                    control={form.control}
+                    name={`packages.${idx}.lessons_count` as const}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Lessons</FormLabel>
+                        <RHFNumberInput field={field} />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name={`packages.${idx}.lesson_duration_minutes` as const}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Duration (min)</FormLabel>
+                        <RHFNumberInput field={field} />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name={`packages.${idx}.price` as const}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Price</FormLabel>
+                        <RHFNumberInput field={field} step="0.01" />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <div className="flex gap-2">
+                    <Button type="button" variant="outline" onClick={() => packagesField.remove(idx)}>Remove</Button>
+                  </div>
+                </div>
+              ))}
+              <Button type="button" variant="outline" onClick={() => packagesField.append({ lessons_count: 1, lesson_duration_minutes: 60, price: 0 })}>Add package</Button>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Media</h3>
+            {signedMediaUrl ? (
+              <div className="space-y-2">
+                <div className="text-sm text-muted-foreground">Current</div>
+                <img src={signedMediaUrl} className="max-h-48 rounded border" />
+                <div>
+                  <Button type="button" variant="destructive" onClick={deleteMedia}>Delete media</Button>
+                </div>
+              </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-3 items-end">
+                <FormField
+                  control={form.control}
+                  name="media_type"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Type</FormLabel>
+                      <select className="border rounded px-3 py-2" value={field.value} onChange={(e) => field.onChange(e.target.value)}>
+                        <option value="image">image</option>
+                        <option value="video">video</option>
+                        <option value="other">other</option>
+                      </select>
+                    </FormItem>
+                  )}
+                />
+                <FormItem>
+                  <FormLabel>File</FormLabel>
+                  <Input type="file" onChange={(e) => form.setValue('media_file', e.target.files as any)} />
+                </FormItem>
+                <FormField
+                  control={form.control}
+                  name="media_description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description</FormLabel>
+                      <Input {...field} placeholder="optional" />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
+          </section>
+
+          <div className="flex gap-3">
+            <Button type="button" variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
+            <Button type="submit" disabled={saving}>{saving ? 'Saving…' : 'Save all'}</Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/frontend/src/pages/coach/CourseEditor.tsx
+++ b/frontend/src/pages/coach/CourseEditor.tsx
@@ -1,0 +1,450 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useForm, useFieldArray } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { supabase } from '@/lib/supabase'
+import { useUser } from '@/contexts/UserContext'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
+
+const modes = ['1v1','1v2','Group','Online'] as const
+const timeSlots = ['Weekdays Morning','Weekdays Afternoon','Weekdays Evening','Weekend Morning','Weekend Afternoon','Weekend Evening'] as const
+const goals = ['Skill Improvement','Competition','Build Interest','Well-being'] as const
+const frequencies = ['1–2 per week','3+ per week','Flexible'] as const
+
+const schema = z.object({
+  training_modes: z.array(z.string()).default([]),
+  available_time_slots: z.array(z.string()).default([]),
+  preferred_frequency: z.string().nullable().optional(),
+  training_goals: z.array(z.string()).default([]),
+  attributes_style: z.array(z.string()).default([]),
+  attributes_prefer: z.array(z.string()).default([]),
+  attributes_not_prefer: z.array(z.string()).default([]),
+  packages: z.array(
+    z.object({
+      id: z.string().optional(),
+      lessons_count: z.coerce.number().int().positive(),
+      lesson_duration_minutes: z.coerce.number().int().positive(),
+      price: z.coerce.number().positive(),
+    })
+  ),
+  media_file: z.any().optional(),
+  media_type: z.enum(['image','video','other']).default('image'),
+  media_description: z.string().optional(),
+})
+
+type FormValues = z.infer<typeof schema>
+
+export default function CourseEditor() {
+  const { id: coachSportId } = useParams()
+  const { user } = useUser()
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [existingCourseId, setExistingCourseId] = useState<string | null>(null)
+  const [signedMediaUrl, setSignedMediaUrl] = useState<string | null>(null)
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      training_modes: [],
+      available_time_slots: [],
+      preferred_frequency: undefined,
+      training_goals: [],
+      attributes_style: [],
+      attributes_prefer: [],
+      attributes_not_prefer: [],
+      packages: [],
+      media_type: 'image',
+    },
+  })
+
+  const packagesField = useFieldArray({ control: form.control, name: 'packages' })
+
+  useEffect(() => {
+    if (!coachSportId) return
+    const run = async () => {
+      setLoading(true)
+      try {
+        const { data: course, error: cErr } = await supabase
+          .from('course_detail')
+          .select('*')
+          .eq('coach_sport_id', coachSportId)
+          .maybeSingle()
+        if (cErr) throw cErr
+        if (course) {
+          setExistingCourseId(course.id)
+          form.reset({
+            training_modes: course.training_modes || [],
+            available_time_slots: course.available_time_slots || [],
+            preferred_frequency: course.preferred_frequency || undefined,
+            training_goals: course.training_goals || [],
+            attributes_style: [],
+            attributes_prefer: [],
+            attributes_not_prefer: [],
+            packages: [],
+            media_type: 'image',
+          })
+        }
+
+        const { data: attrs } = await supabase
+          .from('course_attributes')
+          .select('*')
+          .eq('course_id', course?.id || '')
+
+        if (attrs && attrs.length) {
+          form.setValue('attributes_style', attrs.filter(a => a.type === 'style').map(a => a.value))
+          form.setValue('attributes_prefer', attrs.filter(a => a.type === 'prefer_student').map(a => a.value))
+          form.setValue('attributes_not_prefer', attrs.filter(a => a.type === 'not_prefer_student').map(a => a.value))
+        }
+
+        const { data: pkgs } = await supabase
+          .from('coach_package_prices')
+          .select('*')
+          .eq('coach_sport_id', coachSportId)
+          .order('lessons_count')
+        if (pkgs) {
+          packagesField.replace(
+            pkgs.map((p: any) => ({
+              id: p.id,
+              lessons_count: p.lessons_count,
+              lesson_duration_minutes: p.lesson_duration_minutes,
+              price: Number(p.price),
+            }))
+          )
+        }
+
+        const { data: media } = await supabase
+          .from('coach_media')
+          .select('*')
+          .eq('coach_sport_id', coachSportId)
+          .maybeSingle()
+        if (media?.url) {
+          const { data: signed } = await supabase.storage
+            .from('coach-media')
+            .createSignedUrl(media.url, 3600)
+          if (signed?.signedUrl) setSignedMediaUrl(signed.signedUrl)
+        }
+      } finally {
+        setLoading(false)
+      }
+    }
+    run()
+  }, [coachSportId])
+
+  const saveAll = async (values: FormValues) => {
+    if (!coachSportId || !user) return
+    setSaving(true)
+    try {
+      // upsert course_detail
+      let courseId = existingCourseId
+      if (!courseId) {
+        const { data, error } = await supabase
+          .from('course_detail')
+          .insert({
+            coach_sport_id: coachSportId,
+            training_modes: values.training_modes,
+            available_time_slots: values.available_time_slots,
+            preferred_frequency: values.preferred_frequency || null,
+            training_goals: values.training_goals,
+          })
+          .select('id')
+          .single()
+        if (error) throw error
+        courseId = data.id
+        setExistingCourseId(courseId)
+      } else {
+        const { error } = await supabase
+          .from('course_detail')
+          .update({
+            training_modes: values.training_modes,
+            available_time_slots: values.available_time_slots,
+            preferred_frequency: values.preferred_frequency || null,
+            training_goals: values.training_goals,
+          })
+          .eq('id', courseId)
+        if (error) throw error
+      }
+
+      // replace attributes
+      if (courseId) {
+        await supabase.from('course_attributes').delete().eq('course_id', courseId)
+        const rows: any[] = []
+        values.attributes_style.forEach(v => rows.push({ course_id: courseId, type: 'style', value: v }))
+        values.attributes_prefer.forEach(v => rows.push({ course_id: courseId, type: 'prefer_student', value: v }))
+        values.attributes_not_prefer.forEach(v => rows.push({ course_id: courseId, type: 'not_prefer_student', value: v }))
+        if (rows.length) await supabase.from('course_attributes').insert(rows)
+      }
+
+      // upsert packages
+      const { data: existingPkgs } = await supabase
+        .from('coach_package_prices')
+        .select('id')
+        .eq('coach_sport_id', coachSportId)
+      const existingIds = new Set((existingPkgs || []).map((p: any) => p.id))
+      const newRows = values.packages.filter(p => !p.id).map(p => ({
+        coach_sport_id: coachSportId,
+        lessons_count: p.lessons_count,
+        lesson_duration_minutes: p.lesson_duration_minutes,
+        price: p.price,
+      }))
+      if (newRows.length) await supabase.from('coach_package_prices').insert(newRows)
+      const updateRows = values.packages.filter(p => p.id)
+      for (const p of updateRows) {
+        await supabase
+          .from('coach_package_prices')
+          .update({ lessons_count: p.lessons_count, lesson_duration_minutes: p.lesson_duration_minutes, price: p.price })
+          .eq('id', p.id)
+      }
+      // delete removed
+      const keepIds = new Set(values.packages.filter(p => p.id).map(p => p.id as string))
+      for (const id of existingIds) {
+        if (!keepIds.has(id)) {
+          await supabase.from('coach_package_prices').delete().eq('id', id)
+        }
+      }
+
+      // handle media upload (single row due to PK constraint)
+      const file: File | undefined = (values as any).media_file?.[0]
+      if (file) {
+        const path = `${user.id}/${coachSportId}/${crypto.randomUUID()}-${file.name}`
+        const up = await supabase.storage.from('coach-media').upload(path, file, { upsert: false })
+        if (up.error) throw up.error
+        await supabase
+          .from('coach_media')
+          .upsert({
+            coach_sport_id: coachSportId,
+            coach_id: user.profile?.id || user.id,
+            type: values.media_type,
+            url: up.data.path,
+            description: values.media_description || null,
+          })
+        const { data: signed } = await supabase.storage.from('coach-media').createSignedUrl(path, 3600)
+        if (signed?.signedUrl) setSignedMediaUrl(signed.signedUrl)
+      }
+
+      navigate('/coach')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const deleteMedia = async () => {
+    if (!coachSportId) return
+    const { data: media } = await supabase.from('coach_media').select('*').eq('coach_sport_id', coachSportId).maybeSingle()
+    if (media?.url) {
+      await supabase.storage.from('coach-media').remove([media.url])
+    }
+    await supabase.from('coach_media').delete().eq('coach_sport_id', coachSportId)
+    setSignedMediaUrl(null)
+  }
+
+  if (loading) return <div className="p-6">Loading…</div>
+
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <h2 className="text-xl font-semibold mb-4">Course, Attributes, Prices & Media</h2>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(saveAll)} className="space-y-8">
+          <section className="space-y-3">
+            <h3 className="font-medium">Training modes</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+              {modes.map((m) => (
+                <label key={m} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={form.watch('training_modes').includes(m)}
+                    onCheckedChange={(checked) => {
+                      const cur = new Set(form.getValues('training_modes'))
+                      if (checked) cur.add(m)
+                      else cur.delete(m)
+                      form.setValue('training_modes', Array.from(cur))
+                    }}
+                  />
+                  {m}
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Available time slots</h3>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+              {timeSlots.map((t) => (
+                <label key={t} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={form.watch('available_time_slots').includes(t)}
+                    onCheckedChange={(checked) => {
+                      const cur = new Set(form.getValues('available_time_slots'))
+                      if (checked) cur.add(t)
+                      else cur.delete(t)
+                      form.setValue('available_time_slots', Array.from(cur))
+                    }}
+                  />
+                  {t}
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Preferred frequency</h3>
+            <div className="flex flex-wrap gap-2 text-sm">
+              {frequencies.map((f) => {
+                const selected = form.watch('preferred_frequency') === f
+                return (
+                  <button
+                    type="button"
+                    key={f}
+                    className={`px-3 py-1 rounded border ${selected ? 'bg-black text-white' : ''}`}
+                    onClick={() => form.setValue('preferred_frequency', selected ? undefined : f)}
+                  >
+                    {f}
+                  </button>
+                )
+              })}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Training goals</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+              {goals.map((g) => (
+                <label key={g} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={form.watch('training_goals').includes(g)}
+                    onCheckedChange={(checked) => {
+                      const cur = new Set(form.getValues('training_goals'))
+                      if (checked) cur.add(g)
+                      else cur.delete(g)
+                      form.setValue('training_goals', Array.from(cur))
+                    }}
+                  />
+                  {g}
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Attributes</h3>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <div className="text-sm mb-1">Style</div>
+                <Textarea value={form.watch('attributes_style').join('\n')} onChange={(e) => form.setValue('attributes_style', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
+              </div>
+              <div>
+                <div className="text-sm mb-1">Prefer student</div>
+                <Textarea value={form.watch('attributes_prefer').join('\n')} onChange={(e) => form.setValue('attributes_prefer', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
+              </div>
+              <div>
+                <div className="text-sm mb-1">Not prefer student</div>
+                <Textarea value={form.watch('attributes_not_prefer').join('\n')} onChange={(e) => form.setValue('attributes_not_prefer', e.target.value.split('\n').filter(Boolean))} placeholder="One per line" />
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Packages</h3>
+            <div className="space-y-3">
+              {packagesField.fields.map((field, idx) => (
+                <div key={field.id} className="grid grid-cols-4 gap-3 items-end">
+                  <FormField
+                    control={form.control}
+                    name={`packages.${idx}.lessons_count` as const}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Lessons</FormLabel>
+                        <Input type="number" {...field} />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name={`packages.${idx}.lesson_duration_minutes` as const}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Duration (min)</FormLabel>
+                        <Input type="number" {...field} />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name={`packages.${idx}.price` as const}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Price</FormLabel>
+                        <Input type="number" step="0.01" {...field} />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <div className="flex gap-2">
+                    <Button type="button" variant="outline" onClick={() => packagesField.remove(idx)}>Remove</Button>
+                  </div>
+                </div>
+              ))}
+              <Button type="button" variant="outline" onClick={() => packagesField.append({ lessons_count: 1, lesson_duration_minutes: 60, price: 0 })}>Add package</Button>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">Media</h3>
+            {signedMediaUrl ? (
+              <div className="space-y-2">
+                <div className="text-sm text-muted-foreground">Current</div>
+                <img src={signedMediaUrl} className="max-h-48 rounded border" />
+                <div>
+                  <Button type="button" variant="destructive" onClick={deleteMedia}>Delete media</Button>
+                </div>
+              </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-3 items-end">
+                <FormField
+                  control={form.control}
+                  name="media_type"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Type</FormLabel>
+                      <select className="border rounded px-3 py-2" value={field.value} onChange={(e) => field.onChange(e.target.value)}>
+                        <option value="image">image</option>
+                        <option value="video">video</option>
+                        <option value="other">other</option>
+                      </select>
+                    </FormItem>
+                  )}
+                />
+                <FormItem>
+                  <FormLabel>File</FormLabel>
+                  <Input type="file" onChange={(e) => form.setValue('media_file', e.target.files as any)} />
+                </FormItem>
+                <FormField
+                  control={form.control}
+                  name="media_description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description</FormLabel>
+                      <Input {...field} placeholder="optional" />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
+          </section>
+
+          <div className="flex gap-3">
+            <Button type="button" variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
+            <Button type="submit" disabled={saving}>{saving ? 'Saving…' : 'Save all'}</Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/coach/SportEditor.tsx
+++ b/frontend/src/pages/coach/SportEditor.tsx
@@ -1,17 +1,19 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { supabase } from '@/lib/supabase'
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Form, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
 import { Button } from '@/components/ui/button'
 import { Combobox } from '@/components/ui/combobox'
 import { useUser } from '@/contexts/UserContext'
+import { RHFStringInput, RHFTextarea, RHFSelectString } from '@/components/form/Input'
 
+/** ================== Schema ================== */
 const schema = z.object({
   sport_id: z.string().min(1, 'Select a sport'),
   self_intro: z.string().min(1, 'Required'),
@@ -20,17 +22,21 @@ const schema = z.object({
   certificate_type: z.string().optional(),
 })
 
-type FormValues = z.infer<typeof schema>
+/** 区分输入/输出类型（解决 resolver / RHF 类型不一致的问题） */
+type FormInput = z.input<typeof schema>   // 输入侧（可能含 undefined）
+type FormValues = z.output<typeof schema> // 输出侧（已应用 default/coerce）
 
 export default function SportEditor() {
   const { id } = useParams()
   const navigate = useNavigate()
   const { user } = useUser()
+
   const [sports, setSports] = useState<{ id: string; name: string }[]>([])
   const [loading, setLoading] = useState(false)
   const [file, setFile] = useState<File | null>(null)
 
-  const form = useForm<FormValues>({
+  /** useForm 使用三泛型：<输入, any, 输出> */
+  const form = useForm<FormInput, any, FormValues>({
     resolver: zodResolver(schema),
     defaultValues: {
       sport_id: '',
@@ -42,16 +48,24 @@ export default function SportEditor() {
   })
 
   useEffect(() => {
-    supabase.from('sports').select('id,name').then(({ data }) => setSports((data as any) || []))
+    supabase
+      .from('sports')
+      .select('id,name')
+      .then(({ data }) => setSports((data as any) || []))
   }, [])
 
   useEffect(() => {
     if (!id) return
     const run = async () => {
-      const { data, error } = await supabase.from('coach_sports').select('*').eq('id', id).single()
+      const { data, error } = await supabase
+        .from('coach_sports')
+        .select('*')
+        .eq('id', id)
+        .single()
       if (!error && data) {
+        // reset 使用输入侧形状（允许 undefined）
         form.reset({
-          sport_id: data.sport_id,
+          sport_id: data.sport_id ?? '',
           self_intro: data.self_intro ?? '',
           experience_years: data.experience_years ?? '',
           has_certificate: Boolean(data.has_certificate),
@@ -62,6 +76,7 @@ export default function SportEditor() {
     run()
   }, [id])
 
+  /** onSubmit 接收的是输出类型（已应用 default） */
   const onSubmit = async (values: FormValues) => {
     if (!user) return
     setLoading(true)
@@ -93,16 +108,25 @@ export default function SportEditor() {
           .select('id')
           .single()
         if (error) throw error
+
         if (file) {
           const path = `${user.id}/${data.id}.pdf`
-          const up = await supabase.storage.from('certificate').upload(path, file, { upsert: true })
+          const up = await supabase.storage
+            .from('certificate')
+            .upload(path, file, { upsert: true })
           if (up.error) throw up.error
-          await supabase.from('coach_sports').update({ certificate_url: up.data?.path || path }).eq('id', data.id)
+
+          await supabase
+            .from('coach_sports')
+            .update({ certificate_url: up.data?.path || path })
+            .eq('id', data.id)
         }
       }
+
       navigate('/coach')
     } catch (e) {
-      // noop: toast could be added
+      // TODO: toast error
+      console.error(e)
     } finally {
       setLoading(false)
     }
@@ -110,70 +134,78 @@ export default function SportEditor() {
 
   return (
     <div className="max-w-2xl mx-auto p-6">
-      <h2 className="text-xl font-semibold mb-4">{id ? 'Edit Sport Profile' : 'Create Sport Profile'}</h2>
-      <Form {...form}>
+      <h2 className="text-xl font-semibold mb-4">
+        {id ? 'Edit Sport Profile' : 'Create Sport Profile'}
+      </h2>
+
+      {/* 让 Form 也加上泛型，绑定 RHF 上下文 */}
+      <Form<FormInput> {...form}>
+        {/* handleSubmit 会把 FormValues 传给 onSubmit，类型安全 */}
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-          <FormField
+          <FormField<FormInput>
             control={form.control}
             name="sport_id"
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Sport</FormLabel>
-                <Combobox
+                <RHFSelectString
+                  field={field as any}
                   options={sports.map((s) => ({ value: s.id, label: s.name }))}
-                  value={field.value}
-                  onChange={field.onChange}
+                  // 如果你的 Combobox onChange 返回 option 对象，解开下面这一行即可：
+                  // getValue={(opt) => (opt as any)?.value}
                   placeholder="Select sport"
+                  as={Combobox} // 你的 Combobox 组件
                 />
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          <FormField
+          <FormField<FormInput>
             control={form.control}
             name="self_intro"
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Self introduction</FormLabel>
-                <Textarea {...field} placeholder="Introduce yourself" />
+                <RHFTextarea field={field} placeholder="Introduce yourself" />
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          <FormField
+          <FormField<FormInput>
             control={form.control}
             name="experience_years"
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Experience years</FormLabel>
-                <Input {...field} placeholder="e.g. 3–5 years" />
+                <RHFStringInput field={field} placeholder="e.g. 3–5 years" />
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          <FormField
+          <FormField<FormInput>
             control={form.control}
             name="has_certificate"
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Has certificate</FormLabel>
                 <div className="flex items-center gap-3">
-                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  {/* Switch 需要布尔，强转避免 undefined */}
+                  <Switch checked={!!field.value} onCheckedChange={field.onChange} />
                 </div>
               </FormItem>
             )}
           />
 
-          <FormField
+          <FormField<FormInput>
             control={form.control}
             name="certificate_type"
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Certificate type</FormLabel>
-                <Input {...field} placeholder="e.g. NSCA CSCS" />
+                <RHFStringInput field={field} placeholder="e.g. NSCA CSCS" />
                 <FormMessage />
               </FormItem>
             )}
@@ -185,8 +217,8 @@ export default function SportEditor() {
               type="file"
               accept="image/*,.pdf"
               onChange={(e) => {
-                const f = e.target.files?.[0]
-                if (f) setFile(f)
+                const f = e.target.files?.[0] ?? null
+                setFile(f)
               }}
             />
           </div>
@@ -204,4 +236,3 @@ export default function SportEditor() {
     </div>
   )
 }
-

--- a/frontend/src/pages/coach/SportEditor.tsx
+++ b/frontend/src/pages/coach/SportEditor.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { supabase } from '@/lib/supabase'
+import { Form, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Switch } from '@/components/ui/switch'
+import { Button } from '@/components/ui/button'
+import { Combobox } from '@/components/ui/combobox'
+import { useUser } from '@/contexts/UserContext'
+import { RHFStringInput, RHFTextarea, RHFSelectString } from '@/components/form/Input'
+
+/** ================== Schema ================== */
+const schema = z.object({
+  sport_id: z.string().min(1, 'Select a sport'),
+  self_intro: z.string().min(1, 'Required'),
+  experience_years: z.string().min(1, 'Required'),
+  has_certificate: z.boolean().default(false),
+  certificate_type: z.string().optional(),
+})
+
+/** 区分输入/输出类型（解决 resolver / RHF 类型不一致的问题） */
+type FormInput = z.input<typeof schema>   // 输入侧（可能含 undefined）
+type FormValues = z.output<typeof schema> // 输出侧（已应用 default/coerce）
+
+export default function SportEditor() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { user } = useUser()
+
+  const [sports, setSports] = useState<{ id: string; name: string }[]>([])
+  const [loading, setLoading] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
+
+  /** useForm 使用三泛型：<输入, any, 输出> */
+  const form = useForm<FormInput, any, FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      sport_id: '',
+      self_intro: '',
+      experience_years: '',
+      has_certificate: false,
+      certificate_type: '',
+    },
+  })
+
+  useEffect(() => {
+    supabase
+      .from('sports')
+      .select('id,name')
+      .then(({ data }) => setSports((data as any) || []))
+  }, [])
+
+  useEffect(() => {
+    if (!id) return
+    const run = async () => {
+      const { data, error } = await supabase
+        .from('coach_sports')
+        .select('*')
+        .eq('id', id)
+        .single()
+      if (!error && data) {
+        // reset 使用输入侧形状（允许 undefined）
+        form.reset({
+          sport_id: data.sport_id ?? '',
+          self_intro: data.self_intro ?? '',
+          experience_years: data.experience_years ?? '',
+          has_certificate: Boolean(data.has_certificate),
+          certificate_type: data.certificate_type ?? '',
+        })
+      }
+    }
+    run()
+  }, [id])
+
+  /** onSubmit 接收的是输出类型（已应用 default） */
+  const onSubmit = async (values: FormValues) => {
+    if (!user) return
+    setLoading(true)
+    try {
+      if (id) {
+        const { error } = await supabase
+          .from('coach_sports')
+          .update({
+            sport_id: values.sport_id,
+            self_intro: values.self_intro,
+            experience_years: values.experience_years,
+            has_certificate: values.has_certificate,
+            certificate_type: values.certificate_type ?? null,
+          })
+          .eq('id', id)
+        if (error) throw error
+      } else {
+        const { data, error } = await supabase
+          .from('coach_sports')
+          .insert({
+            coach_id: user.id,
+            sport_id: values.sport_id,
+            self_intro: values.self_intro,
+            experience_years: values.experience_years,
+            has_certificate: values.has_certificate,
+            certificate_type: values.certificate_type ?? null,
+            status: 'pending',
+          })
+          .select('id')
+          .single()
+        if (error) throw error
+
+        if (file) {
+          const path = `${user.id}/${data.id}.pdf`
+          const up = await supabase.storage
+            .from('certificate')
+            .upload(path, file, { upsert: true })
+          if (up.error) throw up.error
+
+          await supabase
+            .from('coach_sports')
+            .update({ certificate_url: up.data?.path || path })
+            .eq('id', data.id)
+        }
+      }
+
+      navigate('/coach')
+    } catch (e) {
+      // TODO: toast error
+      console.error(e)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h2 className="text-xl font-semibold mb-4">
+        {id ? 'Edit Sport Profile' : 'Create Sport Profile'}
+      </h2>
+
+      {/* 让 Form 也加上泛型，绑定 RHF 上下文 */}
+      <Form<FormInput> {...form}>
+        {/* handleSubmit 会把 FormValues 传给 onSubmit，类型安全 */}
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField<FormInput>
+            control={form.control}
+            name="sport_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Sport</FormLabel>
+                <RHFSelectString
+                  field={field as any}
+                  options={sports.map((s) => ({ value: s.id, label: s.name }))}
+                  // 如果你的 Combobox onChange 返回 option 对象，解开下面这一行即可：
+                  // getValue={(opt) => (opt as any)?.value}
+                  placeholder="Select sport"
+                  as={Combobox} // 你的 Combobox 组件
+                />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField<FormInput>
+            control={form.control}
+            name="self_intro"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Self introduction</FormLabel>
+                <RHFTextarea field={field} placeholder="Introduce yourself" />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField<FormInput>
+            control={form.control}
+            name="experience_years"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Experience years</FormLabel>
+                <RHFStringInput field={field} placeholder="e.g. 3–5 years" />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField<FormInput>
+            control={form.control}
+            name="has_certificate"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Has certificate</FormLabel>
+                <div className="flex items-center gap-3">
+                  {/* Switch 需要布尔，强转避免 undefined */}
+                  <Switch checked={!!field.value} onCheckedChange={field.onChange} />
+                </div>
+              </FormItem>
+            )}
+          />
+
+          <FormField<FormInput>
+            control={form.control}
+            name="certificate_type"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Certificate type</FormLabel>
+                <RHFStringInput field={field} placeholder="e.g. NSCA CSCS" />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div>
+            <FormLabel>Upload certificate (image/pdf)</FormLabel>
+            <Input
+              type="file"
+              accept="image/*,.pdf"
+              onChange={(e) => {
+                const f = e.target.files?.[0] ?? null
+                setFile(f)
+              }}
+            />
+          </div>
+
+          <div className="flex gap-3">
+            <Button type="button" variant="outline" onClick={() => navigate(-1)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/frontend/src/pages/coach/SportEditor.tsx
+++ b/frontend/src/pages/coach/SportEditor.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { supabase } from '@/lib/supabase'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Switch } from '@/components/ui/switch'
+import { Button } from '@/components/ui/button'
+import { Combobox } from '@/components/ui/combobox'
+import { useUser } from '@/contexts/UserContext'
+
+const schema = z.object({
+  sport_id: z.string().min(1, 'Select a sport'),
+  self_intro: z.string().min(1, 'Required'),
+  experience_years: z.string().min(1, 'Required'),
+  has_certificate: z.boolean().default(false),
+  certificate_type: z.string().optional(),
+})
+
+type FormValues = z.infer<typeof schema>
+
+export default function SportEditor() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { user } = useUser()
+  const [sports, setSports] = useState<{ id: string; name: string }[]>([])
+  const [loading, setLoading] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      sport_id: '',
+      self_intro: '',
+      experience_years: '',
+      has_certificate: false,
+      certificate_type: '',
+    },
+  })
+
+  useEffect(() => {
+    supabase.from('sports').select('id,name').then(({ data }) => setSports((data as any) || []))
+  }, [])
+
+  useEffect(() => {
+    if (!id) return
+    const run = async () => {
+      const { data, error } = await supabase.from('coach_sports').select('*').eq('id', id).single()
+      if (!error && data) {
+        form.reset({
+          sport_id: data.sport_id,
+          self_intro: data.self_intro ?? '',
+          experience_years: data.experience_years ?? '',
+          has_certificate: Boolean(data.has_certificate),
+          certificate_type: data.certificate_type ?? '',
+        })
+      }
+    }
+    run()
+  }, [id])
+
+  const onSubmit = async (values: FormValues) => {
+    if (!user) return
+    setLoading(true)
+    try {
+      if (id) {
+        const { error } = await supabase
+          .from('coach_sports')
+          .update({
+            sport_id: values.sport_id,
+            self_intro: values.self_intro,
+            experience_years: values.experience_years,
+            has_certificate: values.has_certificate,
+            certificate_type: values.certificate_type ?? null,
+          })
+          .eq('id', id)
+        if (error) throw error
+      } else {
+        const { data, error } = await supabase
+          .from('coach_sports')
+          .insert({
+            coach_id: user.id,
+            sport_id: values.sport_id,
+            self_intro: values.self_intro,
+            experience_years: values.experience_years,
+            has_certificate: values.has_certificate,
+            certificate_type: values.certificate_type ?? null,
+            status: 'pending',
+          })
+          .select('id')
+          .single()
+        if (error) throw error
+        if (file) {
+          const path = `${user.id}/${data.id}.pdf`
+          const up = await supabase.storage.from('certificate').upload(path, file, { upsert: true })
+          if (up.error) throw up.error
+          await supabase.from('coach_sports').update({ certificate_url: up.data?.path || path }).eq('id', data.id)
+        }
+      }
+      navigate('/coach')
+    } catch (e) {
+      // noop: toast could be added
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h2 className="text-xl font-semibold mb-4">{id ? 'Edit Sport Profile' : 'Create Sport Profile'}</h2>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="sport_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Sport</FormLabel>
+                <Combobox
+                  options={sports.map((s) => ({ value: s.id, label: s.name }))}
+                  value={field.value}
+                  onChange={field.onChange}
+                  placeholder="Select sport"
+                />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="self_intro"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Self introduction</FormLabel>
+                <Textarea {...field} placeholder="Introduce yourself" />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="experience_years"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Experience years</FormLabel>
+                <Input {...field} placeholder="e.g. 3–5 years" />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="has_certificate"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Has certificate</FormLabel>
+                <div className="flex items-center gap-3">
+                  <Switch checked={field.value} onCheckedChange={field.onChange} />
+                </div>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="certificate_type"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Certificate type</FormLabel>
+                <Input {...field} placeholder="e.g. NSCA CSCS" />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div>
+            <FormLabel>Upload certificate (image/pdf)</FormLabel>
+            <Input
+              type="file"
+              accept="image/*,.pdf"
+              onChange={(e) => {
+                const f = e.target.files?.[0]
+                if (f) setFile(f)
+              }}
+            />
+          </div>
+
+          <div className="flex gap-3">
+            <Button type="button" variant="outline" onClick={() => navigate(-1)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/community/chatDock/HeaderPanel.tsx
+++ b/frontend/src/pages/community/chatDock/HeaderPanel.tsx
@@ -1,16 +1,19 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { searchUsers, type PublicUserDTO } from "@/api/user";
 import { useChatDockStore } from "./store";
+import { getAvatarPublicUrl } from "@/lib/avatar";
 
 export default function HeaderPanel() {
   const startDM = useChatDockStore((s) => s.startDM);
   const recent = useChatDockStore((s) => s.recentContacts);
+  const addRecentContact = useChatDockStore((s) => s.addRecentContact);
   const [q, setQ] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [list, setList] = useState<PublicUserDTO[]>([]);
   const timer = useRef<number | null>(null);
+  const hydratedRef = useRef<Record<string, boolean>>({});
 
   useEffect(() => {
     if (timer.current) window.clearTimeout(timer.current);
@@ -37,7 +40,59 @@ export default function HeaderPanel() {
     };
   }, [q]);
 
-  const renderUser = (u: { id: string; nickname?: unknown; avatarUrl?: unknown }) => {
+  // 补齐最近联系人中的 nickname / avatar（按需、去重）
+  useEffect(() => {
+    (async () => {
+      for (const u of recent ?? []) {
+        const userId = u?.id;
+        if (!userId || hydratedRef.current[userId]) continue;
+        const hasNickname = typeof u?.nickname === "string" && u.nickname.length > 0;
+        const hasAvatar = typeof u?.avatarUrl === "string" && u.avatarUrl.length > 0;
+        if (hasNickname && hasAvatar) {
+          hydratedRef.current[userId] = true;
+          continue;
+        }
+        try {
+          hydratedRef.current[userId] = true;
+          const users = await searchUsers(userId);
+          const found = Array.isArray(users) && users.length > 0 ? users[0] : undefined;
+          const fallbackAvatar = getAvatarPublicUrl(userId);
+          if (found || fallbackAvatar) {
+            addRecentContact({
+              id: userId,
+              nickname: (found && typeof found.nickname === "string") ? found.nickname : u.nickname,
+              avatarUrl:
+                (found && typeof found.avatarUrl === "string" && found.avatarUrl.length > 0)
+                  ? found.avatarUrl
+                  : (u.avatarUrl ?? fallbackAvatar),
+            });
+          }
+        } catch {
+          // ignore
+        }
+      }
+    })();
+  }, [recent, addRecentContact]);
+
+  const totalUnread = useMemo(() => {
+    let sum = 0;
+    for (const u of recent ?? []) {
+      const n = Number((u as any).unreadCountFromUser ?? 0);
+      if (Number.isFinite(n)) sum += n;
+    }
+    return sum;
+  }, [recent]);
+
+  const sortedRecent = useMemo(() => {
+    const arr = Array.isArray(recent) ? [...recent] : [];
+    return arr.sort((a, b) => {
+      const ta = a.lastMessageAt ? Date.parse(a.lastMessageAt) : 0;
+      const tb = b.lastMessageAt ? Date.parse(b.lastMessageAt) : 0;
+      return tb - ta;
+    });
+  }, [recent]);
+
+  const renderResultItem = (u: { id: string; nickname?: unknown; avatarUrl?: unknown }) => {
     return (
       <div
         key={u.id}
@@ -67,22 +122,63 @@ export default function HeaderPanel() {
   };
 
   return (
-    <div className="w-[280px] bg-white border rounded-lg shadow overflow-hidden">
-      <div className="p-2 border-b bg-gray-50">
+    <div className="w-[360px] bg-white border rounded-lg shadow overflow-hidden">
+      <div className="h-12 px-3 border-b bg-gray-50 flex items-center gap-2">
         <Input placeholder="Search by nickname" value={q} onChange={(e) => setQ(e.target.value)} />
+        <div className="ml-auto text-xs text-gray-600 whitespace-nowrap">Unread: {totalUnread}</div>
       </div>
-      <div className="max-h-72 overflow-y-auto p-2">
-        {q.trim().length >= 2 ? (
-          <div className="space-y-1">
-            {loading && <div className="text-xs text-gray-500">Searching...</div>}
-            {error && <div className="text-xs text-red-600">{error}</div>}
-            {(Array.isArray(list) ? list : []).map((u) => renderUser(u as any))}
-          </div>
-        ) : (
-          <div className="space-y-1">
-            {(Array.isArray(recent) ? recent : []).map((u) => renderUser(u as any))}
+
+      <div className="max-h-[420px] overflow-y-auto p-2">
+        {q.trim().length >= 2 && (
+          <div className="mb-3">
+            <div className="text-[11px] uppercase tracking-wide text-gray-500 px-1 mb-1">Results</div>
+            <div className="space-y-1">
+              {loading && <div className="text-xs text-gray-500">Searching...</div>}
+              {error && <div className="text-xs text-red-600">{error}</div>}
+              {(Array.isArray(list) ? list : []).map((u) => renderResultItem(u as any))}
+              {!loading && !error && list.length === 0 && (
+                <div className="text-xs text-gray-500 px-1 py-1">No users found</div>
+              )}
+            </div>
           </div>
         )}
+
+        <div>
+          <div className="text-[11px] uppercase tracking-wide text-gray-500 px-1 mb-1">Recent</div>
+          {sortedRecent.length === 0 ? (
+            <div className="px-2 py-6 text-sm text-gray-500 text-center">No recent contacts yet</div>
+          ) : (
+            <div className="space-y-1">
+              {sortedRecent.map((u) => {
+                const avatarUrl = typeof u.avatarUrl === "string" && u.avatarUrl.length > 0
+                  ? u.avatarUrl
+                  : (getAvatarPublicUrl(u.id) ?? undefined);
+                return (
+                  <div
+                    key={u.id}
+                    className="flex items-center gap-3 p-2 hover:bg-gray-50 rounded cursor-pointer"
+                    onClick={() => startDM(u.id, { nickname: u.nickname, avatarUrl })}
+                  >
+                    {avatarUrl ? (
+                      <img src={avatarUrl} className="w-9 h-9 rounded-full object-cover" />
+                    ) : (
+                      <div className="w-9 h-9 rounded-full bg-gray-200" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium truncate">{u.nickname ?? u.id}</div>
+                      <div className="text-xs text-gray-500 truncate">{u.lastMessage ?? ""}</div>
+                    </div>
+                    {Number(u.unreadCountFromUser ?? 0) > 0 && (
+                      <div className="text-[10px] bg-red-600 text-white px-2 py-0.5 rounded-full">
+                        {u.unreadCountFromUser}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/community/chatDock/store.ts
+++ b/frontend/src/pages/community/chatDock/store.ts
@@ -103,6 +103,20 @@ const toNumber = (v: unknown, d = 0): number => {
 };
 const isNonEmptyString = (v: unknown): v is string => typeof v === "string" && v.length > 0;
 
+/** 从未知对象里安全取 string 字段 */
+const pickString = (obj: unknown, key: string): string | undefined => {
+  if (!isRecord(obj)) return undefined;
+  const v = obj[key];
+  return typeof v === "string" ? v : undefined;
+};
+
+/** 从未知对象里安全取嵌套对象 */
+const pickRecord = (obj: unknown, key: string): AnyRecord | undefined => {
+  if (!isRecord(obj)) return undefined;
+  const v = obj[key];
+  return isRecord(v) ? v : undefined;
+};
+
 /** API Message DTO（宽松） */
 interface MessageDTO {
   _id?: unknown;
@@ -117,18 +131,12 @@ const normalizeThreadInfo = (tid: string, v: unknown): ChatThreadInfo => {
   const src = isRecord(v) ? v : {};
   return {
     threadId: tid,
-    title: typeof (src as AnyRecord).title === "string" ? ((src as AnyRecord).title as string) : undefined,
-    avatarUrl:
-      typeof (src as AnyRecord).avatarUrl === "string"
-        ? ((src as AnyRecord).avatarUrl as string)
-        : undefined,
-    otherUserId:
-      typeof (src as AnyRecord).otherUserId === "string"
-        ? ((src as AnyRecord).otherUserId as string)
-        : undefined,
-    minimized: !!(src as AnyRecord).minimized,
-    focused: !!(src as AnyRecord).focused,
-    unread: toNumber((src as AnyRecord).unread, 0),
+    title: typeof src.title === "string" ? (src.title as string) : undefined,
+    avatarUrl: typeof src.avatarUrl === "string" ? (src.avatarUrl as string) : undefined,
+    otherUserId: typeof src.otherUserId === "string" ? (src.otherUserId as string) : undefined,
+    minimized: !!src.minimized,
+    focused: !!src.focused,
+    unread: toNumber(src.unread, 0),
   };
 };
 
@@ -136,12 +144,7 @@ const normalizeThreadInfo = (tid: string, v: unknown): ChatThreadInfo => {
 const parseThreadFromUnknown = (
   u: unknown
 ): { id: string; title?: string; avatarUrl?: string; otherUserId?: string } => {
-  const container =
-    isRecord(u) && isRecord((u as AnyRecord).thread)
-      ? ((u as AnyRecord).thread as AnyRecord)
-      : isRecord(u)
-      ? (u as AnyRecord)
-      : {};
+  const container = isRecord(u) && isRecord(u.thread) ? (u.thread as AnyRecord) : (isRecord(u) ? (u as AnyRecord) : {});
 
   const rawId =
     (typeof container.id === "string" && container.id) ||
@@ -153,11 +156,14 @@ const parseThreadFromUnknown = (
   let avatarUrl: string | undefined;
   let otherUserId: string | undefined;
 
-  if (isRecord((container as AnyRecord).otherUser)) {
-    const ou = (container as AnyRecord).otherUser as AnyRecord;
-    if (typeof ou.id === "string") otherUserId = ou.id;
-    if (typeof ou.nickname === "string") title = ou.nickname;
-    if (typeof ou.avatarUrl === "string") avatarUrl = ou.avatarUrl;
+  const other = pickRecord(container, "otherUser");
+  if (other) {
+    const oid = pickString(other, "id");
+    const nick = pickString(other, "nickname");
+    const ava = pickString(other, "avatarUrl");
+    if (oid) otherUserId = oid;
+    if (nick) title = nick;
+    if (ava) avatarUrl = ava;
   }
 
   return { id, title, avatarUrl, otherUserId };
@@ -166,22 +172,16 @@ const parseThreadFromUnknown = (
 /** 解析 getThreadMessages 的单条记录 */
 const parseMessageDTO = (m: unknown, threadId: string, myUserId: string): ChatMessage | null => {
   if (!isRecord(m)) return null;
-  const idRaw = isNonEmptyString((m as AnyRecord)._id)
-    ? (m as AnyRecord)._id
-    : isNonEmptyString((m as AnyRecord).id)
-    ? (m as AnyRecord).id
-    : undefined;
-  const senderIdRaw = (m as AnyRecord).senderId;
-  const contentRaw = (m as AnyRecord).content;
-  const createdAtRaw = (m as AnyRecord).createdAt;
+  const idRaw = isNonEmptyString(m._id) ? m._id : isNonEmptyString(m.id) ? m.id : undefined;
+  const senderIdRaw = m.senderId;
+  const contentRaw = m.content;
+  const createdAtRaw = m.createdAt;
 
   if (!idRaw || !isNonEmptyString(senderIdRaw)) return null;
   const id = toStringSafe(idRaw);
   const senderId = toStringSafe(senderIdRaw);
   const content = isNonEmptyString(contentRaw) ? contentRaw : toStringSafe(contentRaw ?? "");
-  const createdAt = isNonEmptyString(createdAtRaw)
-    ? createdAtRaw
-    : new Date().toISOString();
+  const createdAt = isNonEmptyString(createdAtRaw) ? createdAtRaw : new Date().toISOString();
 
   return {
     id,
@@ -208,10 +208,10 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
       recentContacts: [],
 
       totalUnread: () => {
-        const list = get().recentContacts ?? [];
+        const list: RecentContact[] = get().recentContacts ?? [];
         let sum = 0;
         for (const u of list) {
-          const n = Number((u as any).unreadCountFromUser ?? 0);
+          const n = Number(u.unreadCountFromUser ?? 0);
           if (Number.isFinite(n)) sum += n;
         }
         return sum;
@@ -322,18 +322,26 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
 
         // 初次连接后尝试加载我的线程列表，便于构建最近联系人排序
         try {
-          const threads = await listThreads();
-          // 按 lastMsgAt 更新 recent 的时间戳，保持不丢 nickname/avatar
+          const threadsUnknown: unknown = await listThreads();
+
           set((state) => {
             const map = new Map<string, RecentContact>();
             for (const u of state.recentContacts ?? []) map.set(u.id, { ...u });
-            for (const t of threads ?? []) {
-              const otherId = (t as any)?.otherUser?.id as string | undefined; // 后端简版可能未返回 otherUser
-              if (!otherId) continue;
-              const prev = map.get(otherId) ?? { id: otherId };
-              const lastAt = (t as any)?.lastMsgAt ? String((t as any).lastMsgAt) : prev.lastMessageAt;
-              map.set(otherId, { ...prev, lastMessageAt: lastAt });
+
+            if (Array.isArray(threadsUnknown)) {
+              for (const t of threadsUnknown) {
+                if (!isRecord(t)) continue;
+
+                const otherUser = pickRecord(t, "otherUser");
+                const otherId = otherUser ? pickString(otherUser, "id") : undefined;
+                if (!otherId) continue;
+
+                const prev = map.get(otherId) ?? { id: otherId };
+                const lastAt = pickString(t, "lastMsgAt") ?? prev.lastMessageAt;
+                map.set(otherId, { ...prev, lastMessageAt: lastAt });
+              }
             }
+
             return { ...state, recentContacts: Array.from(map.values()) };
           });
         } catch {
@@ -341,8 +349,8 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
         }
 
         // Disconnect on tab close
-        if (!g.__chatdock_unload_bound) {
-          g.__chatdock_unload_bound = true;
+        if (!(g as AnyRecord).__chatdock_unload_bound) {
+          (g as AnyRecord).__chatdock_unload_bound = true;
 
           globalThis.addEventListener("beforeunload", () => {
             try {
@@ -584,7 +592,11 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
         });
 
         // 3.5) 将联系人加入最近列表（不重复）
-        get().addRecentContact({ id: fromApi ?? otherUserId, nickname: title ?? seed?.nickname, avatarUrl: avatarUrl ?? seed?.avatarUrl });
+        get().addRecentContact({
+          id: fromApi ?? otherUserId,
+          nickname: title ?? seed?.nickname,
+          avatarUrl: avatarUrl ?? seed?.avatarUrl,
+        });
 
         // 4) 加入真实线程（由 joinThread 负责幂等 + 加载历史）
         await get().joinThread(threadId);
@@ -607,12 +619,12 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
           const others = list.filter((u) => u.id !== senderId);
           const prev = list.find((u) => u.id === senderId) ?? { id: senderId };
           const unread = Number(prev.unreadCountFromUser ?? 0) + 1;
-          const next = {
+          const next: RecentContact = {
             ...prev,
             lastMessage: content,
             lastMessageAt: createdAt,
             unreadCountFromUser: unread,
-          } as RecentContact;
+          };
           return { ...state, recentContacts: [next, ...others].slice(0, 50) };
         });
       },
@@ -623,12 +635,12 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
           const list = state.recentContacts ?? [];
           const others = list.filter((u) => u.id !== otherUserId);
           const prev = list.find((u) => u.id === otherUserId) ?? { id: otherUserId };
-          const next = {
+          const next: RecentContact = {
             ...prev,
             lastMessage: content,
             lastMessageAt: createdAt,
             unreadCountFromUser: 0, // 自己发出不产生对端未读计数
-          } as RecentContact;
+          };
           return { ...state, recentContacts: [next, ...others].slice(0, 50) };
         });
       },
@@ -644,7 +656,9 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
       },
 
       disconnectSocket: () => {
-        try { get().socket?.disconnect(); } catch {
+        try {
+          get().socket?.disconnect();
+        } catch {
           console.warn("[chatdock] socket disconnect failed");
         }
         set({ socket: null });
@@ -658,20 +672,21 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
       migrate: (persisted: unknown): PersistedShape => {
         const prev = isRecord(persisted) ? (persisted as PersistedShape) : ({} as PersistedShape);
 
-        const rawOpen = isRecord((prev as AnyRecord).openThreads)
-          ? ((prev as AnyRecord).openThreads as Record<string, unknown>)
+        const rawOpen = isRecord((prev as unknown as AnyRecord).openThreads)
+          ? (((prev as unknown as AnyRecord).openThreads) as Record<string, unknown>)
           : {};
         const fixedOpen: Record<string, ChatThreadInfo> = {};
         for (const [k, v] of Object.entries(rawOpen)) {
-          const tidCandidate = isRecord(v) && isNonEmptyString((v as AnyRecord).threadId)
-            ? ((v as AnyRecord).threadId as string)
-            : k;
+          const tidCandidate =
+            isRecord(v) && isNonEmptyString((v as AnyRecord).threadId)
+              ? ((v as AnyRecord).threadId as string)
+              : k;
           const tid = toStringSafe(tidCandidate);
           if (!tid) continue;
           fixedOpen[tid] = normalizeThreadInfo(tid, v);
         }
 
-        const rawRecentUnknown = (prev as AnyRecord).recentContacts;
+        const rawRecentUnknown = (prev as unknown as AnyRecord).recentContacts;
         const rawRecent: unknown[] = Array.isArray(rawRecentUnknown) ? rawRecentUnknown : [];
 
         const fixedRecent: PersistedShape["recentContacts"] = [];
@@ -679,16 +694,20 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
           if (!isRecord(u)) continue;
 
           let id: string | null = null;
-          if (isNonEmptyString((u as AnyRecord).id)) id = (u as AnyRecord).id as string;
+          if (isNonEmptyString(u.id)) id = u.id;
           else if (isNonEmptyString((u as AnyRecord)._id)) id = String((u as AnyRecord)._id);
           if (!id) continue;
 
           const entry: RecentContact = { id };
-          if (typeof (u as AnyRecord).nickname === "string") entry.nickname = (u as AnyRecord).nickname as string;
-          if (typeof (u as AnyRecord).avatarUrl === "string") entry.avatarUrl = (u as AnyRecord).avatarUrl as string;
-          if (typeof (u as AnyRecord).lastMessage === "string") entry.lastMessage = (u as AnyRecord).lastMessage as string;
-          if (typeof (u as AnyRecord).lastMessageAt === "string") entry.lastMessageAt = (u as AnyRecord).lastMessageAt as string;
-          if (Number.isFinite(Number((u as AnyRecord).unreadCountFromUser))) entry.unreadCountFromUser = Number((u as AnyRecord).unreadCountFromUser);
+          if (typeof u.nickname === "string") entry.nickname = u.nickname;
+          if (typeof u.avatarUrl === "string") entry.avatarUrl = u.avatarUrl;
+          if (typeof u.lastMessage === "string") entry.lastMessage = u.lastMessage;
+          if (typeof u.lastMessageAt === "string") entry.lastMessageAt = u.lastMessageAt;
+
+          const unreadMaybe = (u as AnyRecord).unreadCountFromUser;
+          if (Number.isFinite(Number(unreadMaybe))) {
+            entry.unreadCountFromUser = Number(unreadMaybe);
+          }
 
           fixedRecent.push(entry);
           if (fixedRecent.length >= 50) break;

--- a/frontend/src/pages/community/chatDock/store.ts
+++ b/frontend/src/pages/community/chatDock/store.ts
@@ -2,7 +2,7 @@ import { createWithEqualityFn } from "zustand/traditional";
 import { persist } from "zustand/middleware";
 import { io, Socket } from "socket.io-client";
 import type { ManagerOptions, SocketOptions } from "socket.io-client";
-import { getThreadMessages, startDM as apiStartDM } from "@/api/chat";
+import { getThreadMessages, startDM as apiStartDM, listThreads } from "@/api/chat";
 import { supabase } from "@/lib/supabase";
 
 /** ============ Socket 事件类型 ============ */
@@ -51,17 +51,27 @@ export interface ChatMessage {
 type ThreadSeed = { nickname?: string; avatarUrl?: string };
 
 /** 仅持久化的字段（与 partialize 对齐） */
+export type RecentContact = {
+  id: string;
+  nickname?: string;
+  avatarUrl?: string;
+  lastMessage?: string;
+  lastMessageAt?: string; // ISO
+  unreadCountFromUser?: number;
+};
+
 type PersistedShape = {
   openThreads: Record<string, ChatThreadInfo>;
-  recentContacts: { id: string; nickname?: string; avatarUrl?: string }[];
+  recentContacts: RecentContact[];
 };
 
 /** 完整 Zustand State */
-interface ChatDockState extends PersistedShape {
+export interface ChatDockState extends PersistedShape {
   userId: string | null;
   socket: ChatSocket | null;
 
   messages: Record<string, ChatMessage[]>;
+  totalUnread: () => number;
 
   setUserId: (userId: string | null) => void;
   ensureSocket: (userId: string) => Promise<void>;
@@ -74,6 +84,9 @@ interface ChatDockState extends PersistedShape {
   updateThreadInfo: (threadId: string, patch: Partial<ChatThreadInfo>) => void;
   startDM: (otherUserId: string, seed?: ThreadSeed) => Promise<string>;
   addRecentContact: (user: { id: string; nickname?: string; avatarUrl?: string }) => void;
+  updateRecentOnIncoming: (senderId: string, content: string, createdAt: string) => void;
+  updateRecentOnOutgoing: (otherUserId: string, content: string, createdAt: string) => void;
+  clearUnreadForUser: (userId: string) => void;
   disconnectSocket: () => void;
 }
 
@@ -194,6 +207,16 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
       messages: {},
       recentContacts: [],
 
+      totalUnread: () => {
+        const list = get().recentContacts ?? [];
+        let sum = 0;
+        for (const u of list) {
+          const n = Number((u as any).unreadCountFromUser ?? 0);
+          if (Number.isFinite(n)) sum += n;
+        }
+        return sum;
+      },
+
       setUserId: (userId) => set({ userId }),
 
       ensureSocket: async (userId: string): Promise<void> => {
@@ -280,9 +303,42 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
               },
             }));
           }
+
+          // 更新最近联系人信息（未读按对端累计）
+          if (isMine) {
+            // 自己发的：定位对端用户ID（若已知）
+            const t = get().openThreads[payload.threadId];
+            const otherUserId = t?.otherUserId;
+            if (otherUserId) {
+              get().updateRecentOnOutgoing(otherUserId, payload.content, payload.createdAt);
+            }
+          } else {
+            // 对方发来：senderId 即对方
+            get().updateRecentOnIncoming(payload.senderId, payload.content, payload.createdAt);
+          }
         });
 
         set({ socket: s });
+
+        // 初次连接后尝试加载我的线程列表，便于构建最近联系人排序
+        try {
+          const threads = await listThreads();
+          // 按 lastMsgAt 更新 recent 的时间戳，保持不丢 nickname/avatar
+          set((state) => {
+            const map = new Map<string, RecentContact>();
+            for (const u of state.recentContacts ?? []) map.set(u.id, { ...u });
+            for (const t of threads ?? []) {
+              const otherId = (t as any)?.otherUser?.id as string | undefined; // 后端简版可能未返回 otherUser
+              if (!otherId) continue;
+              const prev = map.get(otherId) ?? { id: otherId };
+              const lastAt = (t as any)?.lastMsgAt ? String((t as any).lastMsgAt) : prev.lastMessageAt;
+              map.set(otherId, { ...prev, lastMessageAt: lastAt });
+            }
+            return { ...state, recentContacts: Array.from(map.values()) };
+          });
+        } catch {
+          // ignore
+        }
 
         // Disconnect on tab close
         if (!g.__chatdock_unload_bound) {
@@ -378,6 +434,13 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
         }));
 
         get().socket?.emit("chat:send", { threadId, content, clientMsgId: rnd });
+
+        // 立刻刷新最近联系人（无需等待服务端回环）
+        const t = get().openThreads[threadId];
+        const otherUserId = t?.otherUserId;
+        if (otherUserId) {
+          get().updateRecentOnOutgoing(otherUserId, content, new Date().toISOString());
+        }
       },
 
       focusThread: (threadId: string) => {
@@ -392,6 +455,10 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
             },
           };
         });
+        // 打开时清除该会话对端的未读
+        const t = get().openThreads[threadId];
+        const otherUserId = t?.otherUserId;
+        if (otherUserId) get().clearUnreadForUser(otherUserId);
       },
 
       minimizeThread: (threadId: string, minimized: boolean) => {
@@ -516,6 +583,9 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
           return { openThreads: next };
         });
 
+        // 3.5) 将联系人加入最近列表（不重复）
+        get().addRecentContact({ id: fromApi ?? otherUserId, nickname: title ?? seed?.nickname, avatarUrl: avatarUrl ?? seed?.avatarUrl });
+
         // 4) 加入真实线程（由 joinThread 负责幂等 + 加载历史）
         await get().joinThread(threadId);
         return threadId;
@@ -525,8 +595,52 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
         if (!user.id) return;
         set((state) => {
           const rest = state.recentContacts.filter((u) => u.id !== user.id);
-          return { ...state, recentContacts: [user, ...rest].slice(0, 20) };
+          const merged = [{ ...user }, ...rest];
+          return { ...state, recentContacts: merged.slice(0, 20) };
         });
+      },
+
+      updateRecentOnIncoming: (senderId, content, createdAt) => {
+        if (!senderId) return;
+        set((state) => {
+          const list = state.recentContacts ?? [];
+          const others = list.filter((u) => u.id !== senderId);
+          const prev = list.find((u) => u.id === senderId) ?? { id: senderId };
+          const unread = Number(prev.unreadCountFromUser ?? 0) + 1;
+          const next = {
+            ...prev,
+            lastMessage: content,
+            lastMessageAt: createdAt,
+            unreadCountFromUser: unread,
+          } as RecentContact;
+          return { ...state, recentContacts: [next, ...others].slice(0, 50) };
+        });
+      },
+
+      updateRecentOnOutgoing: (otherUserId, content, createdAt) => {
+        if (!otherUserId) return;
+        set((state) => {
+          const list = state.recentContacts ?? [];
+          const others = list.filter((u) => u.id !== otherUserId);
+          const prev = list.find((u) => u.id === otherUserId) ?? { id: otherUserId };
+          const next = {
+            ...prev,
+            lastMessage: content,
+            lastMessageAt: createdAt,
+            unreadCountFromUser: 0, // 自己发出不产生对端未读计数
+          } as RecentContact;
+          return { ...state, recentContacts: [next, ...others].slice(0, 50) };
+        });
+      },
+
+      clearUnreadForUser: (userId) => {
+        if (!userId) return;
+        set((state) => ({
+          ...state,
+          recentContacts: (state.recentContacts ?? []).map((u) =>
+            u.id === userId ? { ...u, unreadCountFromUser: 0 } : u
+          ),
+        }));
       },
 
       disconnectSocket: () => {
@@ -538,7 +652,7 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
     }),
     {
       name: "chat-dock",
-      version: 2,
+      version: 3,
       partialize: (s) => ({ openThreads: s.openThreads, recentContacts: s.recentContacts }),
 
       migrate: (persisted: unknown): PersistedShape => {
@@ -569,14 +683,15 @@ export const useChatDockStore = createWithEqualityFn<ChatDockState>()(
           else if (isNonEmptyString((u as AnyRecord)._id)) id = String((u as AnyRecord)._id);
           if (!id) continue;
 
-          const entry: { id: string; nickname?: string; avatarUrl?: string } = { id };
-          if (typeof (u as AnyRecord).nickname === "string")
-            entry.nickname = (u as AnyRecord).nickname as string;
-          if (typeof (u as AnyRecord).avatarUrl === "string")
-            entry.avatarUrl = (u as AnyRecord).avatarUrl as string;
+          const entry: RecentContact = { id };
+          if (typeof (u as AnyRecord).nickname === "string") entry.nickname = (u as AnyRecord).nickname as string;
+          if (typeof (u as AnyRecord).avatarUrl === "string") entry.avatarUrl = (u as AnyRecord).avatarUrl as string;
+          if (typeof (u as AnyRecord).lastMessage === "string") entry.lastMessage = (u as AnyRecord).lastMessage as string;
+          if (typeof (u as AnyRecord).lastMessageAt === "string") entry.lastMessageAt = (u as AnyRecord).lastMessageAt as string;
+          if (Number.isFinite(Number((u as AnyRecord).unreadCountFromUser))) entry.unreadCountFromUser = Number((u as AnyRecord).unreadCountFromUser);
 
           fixedRecent.push(entry);
-          if (fixedRecent.length >= 20) break;
+          if (fixedRecent.length >= 50) break;
         }
 
         return { openThreads: fixedOpen, recentContacts: fixedRecent };

--- a/frontend/src/pages/user/dashboard/Sidebar.tsx
+++ b/frontend/src/pages/user/dashboard/Sidebar.tsx
@@ -6,6 +6,7 @@ const navItems = [
   { label: "Schedule", icon: "📅", path: "/dashboard/schedule" },
   { label: "Messages", icon: "💬", path: "/dashboard/messages" },
   { label: "Posts", icon: "📝", path: "/dashboard/posts" },
+  { label: "Coach Center", icon: "🎓", path: "/coach" },
   { label: "Settings", icon: "⚙️", path: "/dashboard/settings" },
 ]
 


### PR DESCRIPTION
Revamp the "User Search Dock" into a "Recent Contacts Dock" to provide a WeChat/Instagram-style interface for quick access to conversations and unread messages.

This PR replaces the old user search pane with a larger, list-based Recent Contacts Dock, featuring inline search results, total unread count, and recent contact cards with avatars, nicknames, last message previews, and unread badges. The chat store was extended to manage recent contacts, their last message, timestamp, and unread counts, with live updates on message send/receive and unread clearing on thread focus. Initial sorting of recent contacts is based on `lastMsgAt` from the `/chat/threads` API; full historical unread aggregation on socket connect is pending a backend API.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8275875-a8ea-4cac-8ad7-ca504c292c6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8275875-a8ea-4cac-8ad7-ca504c292c6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

