### PR TITLE
Create sport detail page and upgrade editor

### DIFF
--- a/backend/apigateway/src/main/resources/application.properties
+++ b/backend/apigateway/src/main/resources/application.properties
@@ -6,13 +6,13 @@ server.port=8080
 # ==== Spring Cloud Gateway 路由配置 ====
 
 # User Service
-#spring.cloud.gateway.routes[0].id=user-service
-#spring.cloud.gateway.routes[0].uri=http://user-service:8081 
-#spring.cloud.gateway.routes[0].predicates[0]=Path=/users/**
-
 spring.cloud.gateway.routes[0].id=user-service
-spring.cloud.gateway.routes[0].uri=http://localhost:8081 
+spring.cloud.gateway.routes[0].uri=http://user-service:8081 
 spring.cloud.gateway.routes[0].predicates[0]=Path=/users/**
+
+#spring.cloud.gateway.routes[0].id=user-service
+#spring.cloud.gateway.routes[0].uri=http://localhost:8081 
+#spring.cloud.gateway.routes[0].predicates[0]=Path=/users/**
 
 # Coach Service
 # spring.cloud.gateway.routes[2].id=coach-service
@@ -30,14 +30,14 @@ spring.cloud.gateway.routes[0].predicates[0]=Path=/users/**
 # spring.cloud.gateway.routes[4].predicates[0]=Path=/notify/**
 
 # Chat Service (Node.js)
-#spring.cloud.gateway.routes[1].id=chat-service
-#spring.cloud.gateway.routes[1].uri=http://chat-service:4000
-#spring.cloud.gateway.routes[1].predicates[0]=Path=/chat/**
+spring.cloud.gateway.routes[1].id=chat-service
+spring.cloud.gateway.routes[1].uri=http://chat-service:4000
+spring.cloud.gateway.routes[1].predicates[0]=Path=/chat/**
 
 # Chat Service (Node.js)
-spring.cloud.gateway.routes[1].id=chat-service
-spring.cloud.gateway.routes[1].uri=http://localhost:4000
-spring.cloud.gateway.routes[1].predicates[0]=Path=/chat/**
+#spring.cloud.gateway.routes[1].id=chat-service
+#spring.cloud.gateway.routes[1].uri=http://localhost:4000
+#spring.cloud.gateway.routes[1].predicates[0]=Path=/chat/**
 
 # Post Service (Node.js)
 # spring.cloud.gateway.routes[6].id=post-service

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,11 @@ import CommunityPage from './pages/community/CommunityPage';
 import RequireAuth from "./components/RequireAuth";
 import { UserProvider } from "./contexts/UserContext";
 import CoachApplicationForm from "./pages/coach/CoachApplicationForm";
+import CoachCenterPage from "./pages/coach/CoachCenterPage";
+import SportDetailPage from "./pages/coach/SportDetailPage";
+import SportEditor from "./pages/coach/SportEditor";
+import CourseEditor from "./pages/coach/CourseEditor";
+import SessionsPage from "./pages/coach/SessionsPage";
 import ChatDock from "./pages/community/chatDock/ChatDock";
 
 
@@ -47,6 +52,11 @@ function App() {
             <Route path="profile" element={<ProfilePage />} />
           </Route>
           <Route path="/coach-application" element={<CoachApplicationForm />}/>
+          <Route path="/coach" element={<CoachCenterPage />} />
+          <Route path="/coach/sports/:id" element={<SportDetailPage />} />
+          <Route path="/coach/sports/:id/edit" element={<SportEditor />} />
+          <Route path="/coach/sports/:id/course" element={<CourseEditor />} />
+          <Route path="/coach/sports/:id/sessions" element={<SessionsPage />} />
         </Route>
       </Routes>
       {/* Globally mounted Chat Dock (desktop-only) */}

--- a/frontend/src/components/coach/Sport/InfoList.tsx
+++ b/frontend/src/components/coach/Sport/InfoList.tsx
@@ -1,0 +1,24 @@
+type Props = {
+  title: string
+  items: string[]
+  max?: number
+}
+
+export function InfoList({ title, items, max = 6 }: Props) {
+  const visible = items.slice(0, max)
+  const overflow = Math.max(0, items.length - visible.length)
+  return (
+    <div className="space-y-2">
+      <div className="text-sm font-medium text-muted-foreground">{title}</div>
+      <div className="flex flex-wrap gap-2">
+        {visible.map((v, idx) => (
+          <span key={idx} className="px-2 py-1 rounded-full text-xs bg-gray-100 text-gray-700">{v}</span>
+        ))}
+        {overflow > 0 && (
+          <span className="px-2 py-1 rounded-full text-xs bg-gray-50 text-gray-500">+{overflow}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/src/components/coach/Sport/ModeCard.tsx
+++ b/frontend/src/components/coach/Sport/ModeCard.tsx
@@ -1,0 +1,53 @@
+import { Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { InfoList } from './InfoList'
+import { PackageList } from './PackageList'
+import type { CourseVM, TrainingMode } from '@/hooks/useSportDetail'
+
+export type ModeCardProps = {
+  mode: TrainingMode
+  vm: CourseVM
+  sportId: string
+  canSchedule: boolean
+}
+
+export function ModeCard({ mode, vm, sportId, canSchedule }: ModeCardProps) {
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-lg">{mode}</CardTitle>
+        <div className="flex gap-2">
+          <Link to={`/coach/sports/${sportId}/course`}>
+            <Button size="sm" variant="outline">Edit</Button>
+          </Link>
+          <Link to={`/coach/sports/${sportId}/sessions?mode=${encodeURIComponent(mode)}`}>
+            <Button size="sm" disabled={!canSchedule} title={!canSchedule ? 'Available after approval' : undefined}>Schedule</Button>
+          </Link>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="w-full h-40 bg-gray-100 rounded-lg overflow-hidden">
+          {vm.mediaUrl ? (
+            <img src={vm.mediaUrl} className="w-full h-full object-cover" />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-sm text-muted-foreground">No media yet</div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <InfoList title="Goals" items={vm.goals} />
+          <InfoList title="Prefer students" items={vm.prefer} />
+          <InfoList title="Not prefer students" items={vm.notPrefer} />
+          <InfoList title="Coaching style" items={vm.style} />
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-sm font-medium text-muted-foreground">Packages</div>
+          <PackageList items={vm.packages} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/frontend/src/components/coach/Sport/ModeGrid.tsx
+++ b/frontend/src/components/coach/Sport/ModeGrid.tsx
@@ -1,0 +1,13 @@
+import type { CourseVM, TrainingMode } from '@/hooks/useSportDetail'
+import { ModeCard } from './ModeCard'
+
+export function ModeGrid({ vm, sportId, canSchedule }: { vm: CourseVM, sportId: string, canSchedule: boolean }) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {vm.modes.map((mode) => (
+        <ModeCard key={mode} mode={mode as TrainingMode} vm={vm} sportId={sportId} canSchedule={canSchedule} />
+      ))}
+    </div>
+  )
+}
+

--- a/frontend/src/components/coach/Sport/PackageList.tsx
+++ b/frontend/src/components/coach/Sport/PackageList.tsx
@@ -1,0 +1,31 @@
+import { Card } from '@/components/ui/card'
+
+type Package = { id:string; lessons_count:number; lesson_duration_minutes:number; price:number }
+
+function formatPrice(value: number) {
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value)
+  } catch {
+    return `$${value}`
+  }
+}
+
+export function PackageList({ items }: { items: Package[] }) {
+  if (!items.length) {
+    return (
+      <div className="text-sm text-muted-foreground border rounded-lg p-4">No packages yet. Edit course to add.</div>
+    )
+  }
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {items.map((p) => (
+        <div key={p.id} className="border rounded-lg p-4">
+          <div className="font-medium text-sm">{p.lessons_count} lessons</div>
+          <div className="text-xs text-muted-foreground">{p.lesson_duration_minutes} min each</div>
+          <div className="mt-2 font-semibold">{formatPrice(p.price)}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+

--- a/frontend/src/components/coach/Sport/SportHeader.tsx
+++ b/frontend/src/components/coach/Sport/SportHeader.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@/components/ui/button'
+import { Link } from 'react-router-dom'
+
+type Props = {
+  sportName: string
+  status: 'pending'|'approved'|'rejected'
+  sportId: string
+}
+
+export function SportHeader({ sportName, status, sportId }: Props) {
+  const statusColor = status === 'approved' ? 'bg-emerald-100 text-emerald-700' : status === 'pending' ? 'bg-amber-100 text-amber-700' : 'bg-rose-100 text-rose-700'
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div className="flex items-center gap-3">
+        <h1 className="text-2xl font-semibold">{sportName}</h1>
+        <span className={`px-2.5 py-1 rounded-full text-xs ${statusColor}`}>{status}</span>
+      </div>
+      <div className="flex gap-2">
+        <Link to={`/coach/sports/${sportId}/edit`}>
+          <Button variant="outline">Edit sport</Button>
+        </Link>
+        <Link to={`/coach/sports/${sportId}/course`}>
+          <Button variant="outline">Edit course</Button>
+        </Link>
+        <Link to={`/coach/sports/${sportId}/sessions`}>
+          <Button disabled={status !== 'approved'} title={status !== 'approved' ? 'Available after approval' : undefined}>Schedule sessions</Button>
+        </Link>
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/src/components/coach/Sport/SportHeader.tsx
+++ b/frontend/src/components/coach/Sport/SportHeader.tsx
@@ -16,12 +16,6 @@ export function SportHeader({ sportName, status, sportId }: Props) {
         <span className={`px-2.5 py-1 rounded-full text-xs ${statusColor}`}>{status}</span>
       </div>
       <div className="flex gap-2">
-        <Link to={`/coach/sports/${sportId}/edit`}>
-          <Button variant="outline">Edit sport</Button>
-        </Link>
-        <Link to={`/coach/sports/${sportId}/course`}>
-          <Button variant="outline">Edit course</Button>
-        </Link>
         <Link to={`/coach/sports/${sportId}/sessions`}>
           <Button disabled={status !== 'approved'} title={status !== 'approved' ? 'Available after approval' : undefined}>Schedule sessions</Button>
         </Link>

--- a/frontend/src/components/form/inputs.tsx
+++ b/frontend/src/components/form/inputs.tsx
@@ -1,0 +1,86 @@
+import { Controller, FieldPath, FieldValues, UseControllerProps } from 'react-hook-form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+
+type BaseProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>> = {
+  name: TName
+  label?: string
+  placeholder?: string
+  disabled?: boolean
+} & Pick<UseControllerProps<TFieldValues, TName>, 'control' >
+
+export function RHFStringInput<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>(
+  props: BaseProps<TFieldValues, TName>
+) {
+  const { control, name, label, placeholder, disabled } = props
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          {label ? <FormLabel>{label}</FormLabel> : null}
+          <FormControl>
+            <Input {...field} value={field.value ?? ''} onChange={(e) => field.onChange(e.target.value)} placeholder={placeholder} disabled={disabled} />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+export function RHFTextarea<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>(
+  props: BaseProps<TFieldValues, TName>
+) {
+  const { control, name, label, placeholder, disabled } = props
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          {label ? <FormLabel>{label}</FormLabel> : null}
+          <FormControl>
+            <Textarea {...field} value={field.value ?? ''} onChange={(e) => field.onChange(e.target.value)} placeholder={placeholder} disabled={disabled} />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+export function RHFNumberInput<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>(
+  props: BaseProps<TFieldValues, TName>
+) {
+  const { control, name, label, placeholder, disabled } = props
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          {label ? <FormLabel>{label}</FormLabel> : null}
+          <FormControl>
+            <Input
+              type="number"
+              value={field.value ?? ''}
+              onChange={(e) => {
+                const value = e.target.value
+                const parsed = value === '' ? undefined : Number(value)
+                field.onChange(parsed)
+              }}
+              placeholder={placeholder}
+              disabled={disabled}
+              inputMode="numeric"
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+

--- a/frontend/src/hooks/useSportDetail.ts
+++ b/frontend/src/hooks/useSportDetail.ts
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+
+export type TrainingMode = '1v1'|'1v2'|'Group'|'Online'
+
+export type CourseVM = {
+  modes: TrainingMode[]
+  goals: string[]
+  prefer: string[]
+  notPrefer: string[]
+  style: string[]
+  packages: { id: string; lessons_count: number; lesson_duration_minutes: number; price: number }[]
+  mediaUrl?: string | null
+}
+
+type CoachSport = {
+  id: string
+  coach_id: string
+  sport_id: string
+  status: 'pending'|'approved'|'rejected'
+  self_intro: string | null
+  experience_years: string | null
+  has_certificate: boolean | null
+  certificate_type: string | null
+  certificate_url: string | null
+}
+
+type CourseDetail = {
+  id: string
+  coach_sport_id: string
+  training_modes: string[]
+  available_time_slots: string[]
+  preferred_frequency?: string | null
+  training_goals: string[]
+}
+
+type CourseAttribute = {
+  type: 'style' | 'prefer_student' | 'not_prefer_student'
+  value: string
+}
+
+type Package = { id:string; lessons_count:number; lesson_duration_minutes:number; price:number }
+
+type Media = { type: 'image'|'video'|'other'; url: string; description: string | null }
+
+export function useSportDetail(id: string | undefined) {
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const [coachSport, setCoachSport] = useState<CoachSport | null>(null)
+  const [course, setCourse] = useState<CourseDetail | null>(null)
+  const [attributes, setAttributes] = useState<CourseAttribute[]>([])
+  const [packages, setPackages] = useState<Package[]>([])
+  const [mediaUrl, setMediaUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    let isCancelled = false
+    async function fetchAll() {
+      setLoading(true)
+      setError(null)
+      try {
+        const { data: coach, error: coachErr } = await supabase
+          .from('coach_sports')
+          .select('*')
+          .eq('id', id)
+          .single()
+        if (coachErr) throw coachErr
+        if (isCancelled) return
+        setCoachSport(coach as unknown as CoachSport)
+
+        // course_detail by coach_sport_id
+        const { data: courseDetail, error: courseErr } = await supabase
+          .from('course_detail')
+          .select('*')
+          .eq('coach_sport_id', id)
+          .single()
+        if (courseErr && courseErr.code !== 'PGRST116') throw courseErr // 4060 vs not found; allow null
+        setCourse(courseDetail as unknown as CourseDetail | null)
+
+        // attributes by course_id if course exists
+        let attrs: CourseAttribute[] = []
+        if (courseDetail?.id) {
+          const { data: attrData, error: attrErr } = await supabase
+            .from('course_attributes')
+            .select('type,value')
+            .eq('course_id', courseDetail.id)
+          if (attrErr) throw attrErr
+          attrs = (attrData ?? []) as unknown as CourseAttribute[]
+        }
+        setAttributes(attrs)
+
+        // package prices
+        const { data: pkgData, error: pkgErr } = await supabase
+          .from('coach_package_prices')
+          .select('id,lessons_count,lesson_duration_minutes,price')
+          .eq('coach_sport_id', id)
+        if (pkgErr) throw pkgErr
+        setPackages((pkgData ?? []) as unknown as Package[])
+
+        // media: maybe single; get signed URL if present
+        const { data: mediaData, error: mediaErr } = await supabase
+          .from('coach_media')
+          .select('type,url,description')
+          .eq('coach_sport_id', id)
+          .maybeSingle()
+        if (mediaErr && mediaErr.code !== 'PGRST116') throw mediaErr
+        if (mediaData?.url) {
+          const path = mediaData.url
+          const { data: signed } = await supabase.storage.from('coach-media').createSignedUrl(path, 60 * 60)
+          setMediaUrl(signed?.signedUrl ?? null)
+        } else {
+          setMediaUrl(null)
+        }
+      } catch (e: any) {
+        console.error(e)
+        setError(e?.message ?? 'Failed to load')
+      } finally {
+        if (!isCancelled) setLoading(false)
+      }
+    }
+    fetchAll()
+    return () => { isCancelled = true }
+  }, [id])
+
+  const courseVM: CourseVM | null = useMemo(() => {
+    if (!course) return null
+    const modes = (course.training_modes ?? []).filter(Boolean) as TrainingMode[]
+    const goals = course.training_goals ?? []
+    const prefer = attributes.filter(a => a.type === 'prefer_student').map(a => a.value)
+    const notPrefer = attributes.filter(a => a.type === 'not_prefer_student').map(a => a.value)
+    const style = attributes.filter(a => a.type === 'style').map(a => a.value)
+    return { modes, goals, prefer, notPrefer, style, packages, mediaUrl }
+  }, [course, attributes, packages, mediaUrl])
+
+  const canSchedule = coachSport?.status === 'approved'
+
+  return { loading, error, coachSport, course, attributes, packages, mediaUrl, courseVM, canSchedule }
+}
+

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -57,7 +57,7 @@ export default function HomePage() {
                   <DropdownMenuItem onClick={() => navigate("/dashboard")}>
                     Personal Dashboard
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => navigate("/become-coach")}>
+                  <DropdownMenuItem onClick={() => navigate("/coach-application")}>
                     Become a Coach
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => navigate("/manage-venue")}>

--- a/frontend/src/pages/coach/CoachCenterPage.tsx
+++ b/frontend/src/pages/coach/CoachCenterPage.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { supabase } from '@/lib/supabase'
 
-type CoachSport = { id: string; sport_id: string; status: 'pending'|'approved'|'rejected' }
+type CoachSport = {
+  id: string
+  status: 'pending' | 'approved' | 'rejected'
+  sports: { id: string; name: string } | null
+}
 
 export default function CoachCenterPage() {
   const [items, setItems] = useState<CoachSport[]>([])
@@ -14,14 +18,28 @@ export default function CoachCenterPage() {
       try {
         const { data: { session } } = await supabase.auth.getSession()
         const coachId = session?.user?.id
-        if (!coachId) { setItems([]); return }
-        const { data } = await supabase.from('coach_sports').select('id,sport_id,status').eq('coach_id', coachId)
+        if (!coachId) {
+          setItems([])
+          return
+        }
+        const { data, error } = await supabase
+          .from('coach_sports')
+          .select(`
+            id,
+            status,
+            sports ( id, name )
+          `)
+          .eq('coach_id', coachId)
+
+        if (error) throw error
         if (mounted) setItems((data ?? []) as any)
       } finally {
         if (mounted) setLoading(false)
       }
     })()
-    return () => { mounted = false }
+    return () => {
+      mounted = false
+    }
   }, [])
 
   if (loading) return <div className="p-6">Loading…</div>
@@ -31,8 +49,15 @@ export default function CoachCenterPage() {
       <h1 className="text-2xl font-semibold">Coach Center</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {items.map((it) => (
-          <Link key={it.id} to={`/coach/sports/${it.id}`} className="border rounded-lg p-4 hover:shadow">
-            <div className="font-medium">{it.sport_id}</div>
+          <Link
+            key={it.id}
+            to={`/coach/sports/${it.id}`}
+            state={{ sportName: it.sports?.name }} 
+            className="border rounded-lg p-4 hover:shadow"
+          >
+            <div className="font-medium">
+              {it.sports?.name ?? 'Unknown sport'}
+            </div>
             <div className="text-xs text-muted-foreground">{it.status}</div>
           </Link>
         ))}
@@ -40,4 +65,3 @@ export default function CoachCenterPage() {
     </div>
   )
 }
-

--- a/frontend/src/pages/coach/CoachCenterPage.tsx
+++ b/frontend/src/pages/coach/CoachCenterPage.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { supabase } from '@/lib/supabase'
+
+type CoachSport = { id: string; sport_id: string; status: 'pending'|'approved'|'rejected' }
+
+export default function CoachCenterPage() {
+  const [items, setItems] = useState<CoachSport[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let mounted = true
+    ;(async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession()
+        const coachId = session?.user?.id
+        if (!coachId) { setItems([]); return }
+        const { data } = await supabase.from('coach_sports').select('id,sport_id,status').eq('coach_id', coachId)
+        if (mounted) setItems((data ?? []) as any)
+      } finally {
+        if (mounted) setLoading(false)
+      }
+    })()
+    return () => { mounted = false }
+  }, [])
+
+  if (loading) return <div className="p-6">Loading…</div>
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Coach Center</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {items.map((it) => (
+          <Link key={it.id} to={`/coach/sports/${it.id}`} className="border rounded-lg p-4 hover:shadow">
+            <div className="font-medium">{it.sport_id}</div>
+            <div className="text-xs text-muted-foreground">{it.status}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/coach/CourseEditor.tsx
+++ b/frontend/src/pages/coach/CourseEditor.tsx
@@ -1,0 +1,12 @@
+import { useParams } from 'react-router-dom'
+
+export default function CourseEditor() {
+  const { id } = useParams()
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold">Course Editor</h1>
+      <p className="text-sm text-muted-foreground">TODO: Keep existing CourseEditor; this is a placeholder for routing. Coach sport id: {id}</p>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/coach/SessionsPage.tsx
+++ b/frontend/src/pages/coach/SessionsPage.tsx
@@ -1,0 +1,14 @@
+import { useParams, useSearchParams } from 'react-router-dom'
+
+export default function SessionsPage() {
+  const { id } = useParams()
+  const [params] = useSearchParams()
+  const mode = params.get('mode')
+  return (
+    <div className="p-6 space-y-2">
+      <h1 className="text-xl font-semibold">Sessions</h1>
+      <div className="text-sm text-muted-foreground">TODO: Implement sessions editor. Preselected mode: {mode ?? '—'} for sport {id}</div>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/coach/SportDetailPage.tsx
+++ b/frontend/src/pages/coach/SportDetailPage.tsx
@@ -1,0 +1,54 @@
+import { useParams, Link } from 'react-router-dom'
+import { useSportDetail } from '@/hooks/useSportDetail'
+import { SportHeader } from '@/components/coach/Sport/SportHeader'
+import { ModeGrid } from '@/components/coach/Sport/ModeGrid'
+
+export default function SportDetailPage() {
+  const { id } = useParams()
+  const { loading, error, coachSport, courseVM, canSchedule } = useSportDetail(id)
+
+  if (loading) {
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-40 bg-gray-100 rounded" />
+        <div className="h-5 w-72 bg-gray-100 rounded" />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="h-72 bg-gray-100 rounded" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-600">{error}</div>
+  }
+
+  if (!coachSport) {
+    return <div className="p-6">Not found.</div>
+  }
+
+  const sportName = coachSport.sport_id // Ideally join to sports table; placeholder
+
+  return (
+    <div className="p-6 space-y-6">
+      <SportHeader sportName={sportName} status={coachSport.status} sportId={coachSport.id} />
+
+      {!courseVM ? (
+        <div className="border rounded-lg p-4 text-sm text-muted-foreground">
+          <div>You haven’t set up your course profile yet.</div>
+          <Link to={`/coach/sports/${coachSport.id}/course`} className="text-blue-600">Edit course</Link>
+        </div>
+      ) : courseVM.modes.length === 0 ? (
+        <div className="border rounded-lg p-4 text-sm text-muted-foreground">
+          <div>No training modes selected.</div>
+          <Link to={`/coach/sports/${coachSport.id}/course`} className="text-blue-600">Choose modes</Link>
+        </div>
+      ) : (
+        <ModeGrid vm={courseVM} sportId={coachSport.id} canSchedule={canSchedule} />
+      )}
+    </div>
+  )
+}
+

--- a/frontend/src/pages/coach/SportDetailPage.tsx
+++ b/frontend/src/pages/coach/SportDetailPage.tsx
@@ -1,11 +1,39 @@
-import { useParams, Link } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { useParams, Link, useLocation } from 'react-router-dom'
+import { supabase } from '@/lib/supabase'
 import { useSportDetail } from '@/hooks/useSportDetail'
 import { SportHeader } from '@/components/coach/Sport/SportHeader'
 import { ModeGrid } from '@/components/coach/Sport/ModeGrid'
 
 export default function SportDetailPage() {
   const { id } = useParams()
+  const location = useLocation() as { state?: { sportName?: string } }
   const { loading, error, coachSport, courseVM, canSchedule } = useSportDetail(id)
+
+  // 先用 Link.state 里的名字
+  const [resolvedSportName, setResolvedSportName] = useState<string | null>(
+    location.state?.sportName ?? null
+  )
+
+  // 如果没有名字但有 sport_id，就兜底查 sports 表
+  useEffect(() => {
+    let mounted = true
+    if (!resolvedSportName && coachSport?.sport_id) {
+      supabase
+        .from('sports')
+        .select('name')
+        .eq('id', coachSport.sport_id)
+        .maybeSingle()
+        .then(({ data }) => {
+          if (mounted) {
+            setResolvedSportName(data?.name ?? null)
+          }
+        })
+    }
+    return () => {
+      mounted = false
+    }
+  }, [resolvedSportName, coachSport?.sport_id])
 
   if (loading) {
     return (
@@ -29,26 +57,44 @@ export default function SportDetailPage() {
     return <div className="p-6">Not found.</div>
   }
 
-  const sportName = coachSport.sport_id // Ideally join to sports table; placeholder
+  // 最终展示名：优先 state，其次兜底查询，最后才退回 id
+  const sportName = resolvedSportName ?? coachSport.sport_id
 
   return (
     <div className="p-6 space-y-6">
-      <SportHeader sportName={sportName} status={coachSport.status} sportId={coachSport.id} />
+      <SportHeader
+        sportName={sportName}
+        status={coachSport.status}
+        sportId={coachSport.id}
+      />
 
       {!courseVM ? (
         <div className="border rounded-lg p-4 text-sm text-muted-foreground">
           <div>You haven’t set up your course profile yet.</div>
-          <Link to={`/coach/sports/${coachSport.id}/course`} className="text-blue-600">Edit course</Link>
+          <Link
+            to={`/coach/sports/${coachSport.id}/course`}
+            className="text-blue-600"
+          >
+            Edit course
+          </Link>
         </div>
       ) : courseVM.modes.length === 0 ? (
         <div className="border rounded-lg p-4 text-sm text-muted-foreground">
           <div>No training modes selected.</div>
-          <Link to={`/coach/sports/${coachSport.id}/course`} className="text-blue-600">Choose modes</Link>
+          <Link
+            to={`/coach/sports/${coachSport.id}/course`}
+            className="text-blue-600"
+          >
+            Choose modes
+          </Link>
         </div>
       ) : (
-        <ModeGrid vm={courseVM} sportId={coachSport.id} canSchedule={canSchedule} />
+        <ModeGrid
+          vm={courseVM}
+          sportId={coachSport.id}
+          canSchedule={canSchedule}
+        />
       )}
     </div>
   )
 }
-

--- a/frontend/src/pages/coach/SportEditor.tsx
+++ b/frontend/src/pages/coach/SportEditor.tsx
@@ -1,0 +1,46 @@
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Form } from '@/components/ui/form'
+import { RHFStringInput, RHFTextarea } from '@/components/form/inputs'
+import { Button } from '@/components/ui/button'
+import { useParams } from 'react-router-dom'
+import { supabase } from '@/lib/supabase'
+
+const schema = z.object({
+  self_intro: z.string().min(1).optional(),
+  experience_years: z.string().optional(),
+  certificate_type: z.string().optional(),
+})
+
+type FormInput = z.input<typeof schema>
+type FormValues = z.output<typeof schema>
+
+export default function SportEditor() {
+  const { id } = useParams()
+  const form = useForm<FormInput, any, FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { self_intro: '', experience_years: '', certificate_type: '' }
+  })
+
+  const onSubmit = async (values: FormValues) => {
+    if (!id) return
+    await supabase.from('coach_sports').update(values).eq('id', id)
+    alert('Saved')
+  }
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold mb-4">Edit Sport</h1>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 max-w-xl">
+          <RHFTextarea control={form.control} name={'self_intro'} label="Self introduction" placeholder="Introduce yourself" />
+          <RHFStringInput control={form.control} name={'experience_years'} label="Experience years" placeholder="e.g. 3–5 years" />
+          <RHFStringInput control={form.control} name={'certificate_type'} label="Certificate type" placeholder="e.g. NASM CPT" />
+          <Button type="submit">Save</Button>
+        </form>
+      </Form>
+    </div>
+  )
+}
+


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement the Coach Center Sport Detail page with mode-based course display and upgrade SportEditor with RHF controlled inputs.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR introduces the `/coach/sports/:id` route, rendering a detailed view of a coach's sport profile. Course information is presented in sections per training mode, displaying goals, student preferences, coaching style, packages, and media. It also refactors `SportEditor` to use new shared RHF input components, resolving `value: unknown | boolean` TypeScript issues and improving form consistency. Loading, empty, and permission states are handled, and the layout is responsive.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a410645-6314-41e3-944d-29f3244f70a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a410645-6314-41e3-944d-29f3244f70a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

