### PR TITLE
Make course cards fill content width

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,10 +52,6 @@ function App() {
           <Route path="/dashboard" element={<Dashboard />}>
             <Route index element={<ProfilePage />} />
             <Route path="profile" element={<ProfilePage />} />
-          </Route>
-
-          {/* New fixed-sidebar dashboard layout for coach center */}
-          <Route path="/dashboard" element={<DashboardLayout />}>
             <Route path="coach" element={<CoachLayout />}>
               <Route index element={<CoachCenterPage />} />
               <Route path="sports/new" element={<SportEditor />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,9 @@
 import Login from "./pages/auth/Login";
 import Dashboard from './pages/user/dashboard/Dashboard';
+import DashboardLayout from '@/layouts/DashboardLayout'
+import CoachLayout from '@/layouts/CoachLayout'
 import './App.css';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, Navigate } from 'react-router-dom';
 import SignUp from './pages/auth/SignUp';
 import ResetPassword from "./pages/auth/ResetPwd";
 import ForgetPassword from "./pages/auth/ForgetPwd";
@@ -46,23 +48,43 @@ function App() {
         </Route>
 
         <Route element={<RequireAuth/>}>
+          {/* Existing user dashboard */}
           <Route path="/dashboard" element={<Dashboard />}>
             <Route index element={<ProfilePage />} />
             <Route path="profile" element={<ProfilePage />} />
           </Route>
-          
+
+          {/* New fixed-sidebar dashboard layout for coach center */}
+          <Route path="/dashboard" element={<DashboardLayout />}>
+            <Route path="coach" element={<CoachLayout />}>
+              <Route index element={<CoachCenterPage />} />
+              <Route path="sports/new" element={<SportEditor />} />
+              <Route path="sports/:id" element={<SportDetailPage />} />
+              <Route path="sports/:id/edit" element={<SportEditor />} />
+              <Route path="sports/:coachSportId/course" element={<CourseEditor />} />
+              <Route path="sports/:coachSportId/course/new" element={<CourseEditorPage />} />
+              <Route path="sports/:coachSportId/course/:courseId/edit" element={<CourseEditorPage />} />
+              <Route path="sports/:id/sessions" element={<SessionsPage />} />
+            </Route>
+          </Route>
         </Route>
+
+        {/* Full-screen onboarding (no sidebar) */}
+        <Route path="/coach/onboarding" element={<CoachApplicationForm />} />
+        <Route path="/become-a-coach" element={<Navigate to="/coach/onboarding" replace />} />
 
         <Route element={<RequireAuth requireProfile = {false}/>}>
           <Route path="/coach-application" element={<CoachApplicationForm />}/>
-          <Route path="/coach" element={<CoachCenterPage />} />
-          <Route path="/coach/sports/:id" element={<SportDetailPage />} />
-          <Route path="/coach/sports/:id/edit" element={<SportEditor />} />
-          <Route path="/coach/sports/:coachSportId/course" element={<CourseEditor />} />
-          <Route path="/coach/sports/:coachSportId/course/new" element={<CourseEditorPage />} />
-          <Route path="/coach/sports/:coachSportId/course/:courseId/edit" element={<CourseEditorPage />} />
-          <Route path="/coach/sports/:id/sessions" element={<SessionsPage />} />
         </Route>
+
+        {/* Legacy redirects from old /coach paths to new /dashboard/coach paths */}
+        <Route path="/coach" element={<Navigate to="/dashboard/coach" replace />} />
+        <Route path="/coach/sports/:id" element={<Navigate to="/dashboard/coach/sports/:id" replace />} />
+        <Route path="/coach/sports/:id/edit" element={<Navigate to="/dashboard/coach/sports/:id/edit" replace />} />
+        <Route path="/coach/sports/:coachSportId/course" element={<Navigate to="/dashboard/coach/sports/:coachSportId/course" replace />} />
+        <Route path="/coach/sports/:coachSportId/course/new" element={<Navigate to="/dashboard/coach/sports/:coachSportId/course/new" replace />} />
+        <Route path="/coach/sports/:coachSportId/course/:courseId/edit" element={<Navigate to="/dashboard/coach/sports/:coachSportId/course/:courseId/edit" replace />} />
+        <Route path="/coach/sports/:id/sessions" element={<Navigate to="/dashboard/coach/sports/:id/sessions" replace />} />
       </Routes>
       {/* Globally mounted Chat Dock (desktop-only) */}
       <ChatDock />

--- a/frontend/src/components/coach/Sport/ModeCard.tsx
+++ b/frontend/src/components/coach/Sport/ModeCard.tsx
@@ -22,14 +22,14 @@ export function ModeCard({ mode, vm, sportId, canSchedule, courseId, onDelete, d
         <CardTitle className="text-lg">{mode}</CardTitle>
         <div className="flex gap-2">
           {courseId ? (
-            <Link to={`/coach/sports/${sportId}/course/${courseId}/edit`}>
+            <Link to={`/dashboard/coach/sports/${sportId}/course/${courseId}/edit`}>
               <Button size="sm" variant="outline" className="text-black">Edit</Button>
             </Link>
           ) : null}
           {courseId ? (
             <Button size="sm" variant="outline" className="text-black" onClick={onDelete} disabled={deleting}>Delete</Button>
           ) : null}
-          <Link to={`/coach/sports/${sportId}/sessions?mode=${encodeURIComponent(mode)}`}>
+          <Link to={`/dashboard/coach/sports/${sportId}/sessions?mode=${encodeURIComponent(mode)}`}>
             <Button size="sm" disabled={!canSchedule} title={!canSchedule ? 'Available after approval' : undefined}>Schedule</Button>
           </Link>
         </div>

--- a/frontend/src/components/coach/Sport/ModeCard.tsx
+++ b/frontend/src/components/coach/Sport/ModeCard.tsx
@@ -17,7 +17,7 @@ export type ModeCardProps = {
 
 export function ModeCard({ mode, vm, sportId, canSchedule, courseId, onDelete, deleting }: ModeCardProps) {
   return (
-    <Card className="overflow-hidden">
+    <Card className="overflow-hidden w-full">
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle className="text-lg">{mode}</CardTitle>
         <div className="flex gap-2">

--- a/frontend/src/components/coach/Sport/ModeGrid.tsx
+++ b/frontend/src/components/coach/Sport/ModeGrid.tsx
@@ -3,7 +3,7 @@ import { ModeCard } from './ModeCard'
 
 export function ModeGrid({ vm, sportId, canSchedule, courseId, onDelete, deleting }: { vm: CourseVM, sportId: string, canSchedule: boolean, courseId?: string, onDelete?: () => void, deleting?: boolean }) {
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div className="flex flex-col gap-4 w-full min-w-0">
       {vm.modes.map((mode) => (
         <ModeCard key={mode} mode={mode as TrainingMode} vm={vm} sportId={sportId} canSchedule={canSchedule} courseId={courseId} onDelete={onDelete} deleting={deleting} />
       ))}

--- a/frontend/src/components/coach/Sport/SportHeader.tsx
+++ b/frontend/src/components/coach/Sport/SportHeader.tsx
@@ -16,7 +16,7 @@ export function SportHeader({ sportName, status, sportId }: Props) {
         <span className={`px-2.5 py-1 rounded-full text-xs ${statusColor}`}>{status}</span>
       </div>
       <div className="flex gap-2">
-        <Link to={`/coach/sports/${sportId}/sessions`}>
+        <Link to={`/dashboard/coach/sports/${sportId}/sessions`}>
           <Button disabled={status !== 'approved'} title={status !== 'approved' ? 'Available after approval' : undefined}>Schedule sessions</Button>
         </Link>
       </div>

--- a/frontend/src/layouts/CoachLayout.tsx
+++ b/frontend/src/layouts/CoachLayout.tsx
@@ -1,0 +1,21 @@
+import { Outlet, NavLink } from 'react-router-dom'
+
+export default function CoachLayout() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Coach Center</h1>
+        <nav className="flex gap-3 text-sm">
+          <NavLink to="/dashboard/coach" className={({ isActive }) => isActive ? 'font-medium' : 'text-muted-foreground'}>
+            Overview
+          </NavLink>
+          <NavLink to="/dashboard/coach/sports/new" className={({ isActive }) => isActive ? 'font-medium' : 'text-muted-foreground'}>
+            New Sport
+          </NavLink>
+        </nav>
+      </div>
+      <Outlet />
+    </div>
+  )
+}
+

--- a/frontend/src/layouts/DashboardLayout.tsx
+++ b/frontend/src/layouts/DashboardLayout.tsx
@@ -1,0 +1,21 @@
+import { Outlet } from 'react-router-dom'
+import { Sidebar } from '@/pages/user/dashboard/Sidebar'
+
+export default function DashboardLayout() {
+  return (
+    <div className="min-h-screen flex bg-gray-50">
+      {/* Fixed left sidebar */}
+      <aside className="w-64 shrink-0 border-r bg-white sticky top-0 h-screen">
+        <Sidebar />
+      </aside>
+
+      {/* Scrollable right content */}
+      <main className="flex-1 min-w-0 h-screen overflow-y-auto">
+        <div className="max-w-6xl mx-auto w-full p-6">
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/coach/CoachCenterPage.tsx
+++ b/frontend/src/pages/coach/CoachCenterPage.tsx
@@ -51,7 +51,7 @@ export default function CoachCenterPage() {
         {items.map((it) => (
           <Link
             key={it.id}
-            to={`/coach/sports/${it.id}`}
+            to={`/dashboard/coach/sports/${it.id}`}
             state={{ sportName: it.sports?.name }} 
             className="border rounded-lg p-4 hover:shadow"
           >

--- a/frontend/src/pages/coach/CoachDashboard.tsx
+++ b/frontend/src/pages/coach/CoachDashboard.tsx
@@ -131,7 +131,7 @@ export default function CoachDashboard() {
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-semibold">Coach Center</h2>
         <div className="flex gap-3">
-          <Link to="/coach/sports/new">
+          <Link to="/dashboard/coach/sports/new">
             <Button>Create profile</Button>
           </Link>
         </div>
@@ -169,8 +169,8 @@ export default function CoachDashboard() {
                     </div>
                   </div>
                   <div className="flex gap-2 pt-2">
-                    <Button variant="outline" onClick={() => navigate(`/coach/sports/${cs.id}/edit`)}>Edit</Button>
-                    <Button onClick={() => navigate(`/coach/sports/${cs.id}/course`)}>Course & Packages</Button>
+                    <Button variant="outline" onClick={() => navigate(`/dashboard/coach/sports/${cs.id}/edit`)}>Edit</Button>
+                    <Button onClick={() => navigate(`/dashboard/coach/sports/${cs.id}/course`)}>Course & Packages</Button>
                   </div>
                 </CardContent>
               </Card>

--- a/frontend/src/pages/coach/CourseEditorPage.tsx
+++ b/frontend/src/pages/coach/CourseEditorPage.tsx
@@ -289,7 +289,7 @@ export default function CourseEditorPage() {
       const ok = window.confirm('You have unsaved changes, leave anyway?')
       if (!ok) return
     }
-    navigate(`/coach/sports/${coachSportId}`, { state: { sportName } })
+    navigate(`/dashboard/coach/sports/${coachSportId}`, { state: { sportName } })
   }, [form.formState.isDirty, coachSportId, navigate, sportName])
 
   const onSubmit = form.handleSubmit(async (values) => {
@@ -387,7 +387,7 @@ export default function CourseEditorPage() {
       }
 
       window.alert('Saved')
-      navigate(`/coach/sports/${coachSportId}`, { state: { sportName } })
+      navigate(`/dashboard/coach/sports/${coachSportId}`, { state: { sportName } })
     } catch (e: any) {
       console.error(e)
       window.alert(e?.message ?? 'Failed to save')

--- a/frontend/src/pages/coach/SportDetailPage.tsx
+++ b/frontend/src/pages/coach/SportDetailPage.tsx
@@ -111,10 +111,10 @@ export default function SportDetailPage() {
           </div>
         </div>
       ) : (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="space-y-6 w-full">
           {courseVMs.map(({ courseId, vm }) => {
             return (
-              <div key={courseId} className="h-full">
+              <div key={courseId} className="w-full">
                 <ModeGrid
                   vm={vm}
                   sportId={coachSport.id}

--- a/frontend/src/pages/coach/SportDetailPage.tsx
+++ b/frontend/src/pages/coach/SportDetailPage.tsx
@@ -101,7 +101,7 @@ export default function SportDetailPage() {
             <Button
               className="text-black"
               onClick={() =>
-                navigate(`/coach/sports/${coachSport.id}/course/new`, {
+                navigate(`/dashboard/coach/sports/${coachSport.id}/course/new`, {
                   state: { sportName },
                 })
               }
@@ -136,7 +136,7 @@ export default function SportDetailPage() {
           <Button
             className="text-black"
             onClick={() =>
-              navigate(`/coach/sports/${coachSport.id}/course/new`, {
+              navigate(`/dashboard/coach/sports/${coachSport.id}/course/new`, {
                 state: { sportName },
               })
             }

--- a/frontend/src/pages/community/CommunityPage.tsx
+++ b/frontend/src/pages/community/CommunityPage.tsx
@@ -17,7 +17,7 @@ export default function CommunityPage() {
   useEffect(() => {
     if (user?.id) {
       setCurrentUserId(user.id);
-      ensureSocket(user.id);
+      ensureSocket();
     }
   }, [user?.id, ensureSocket, setCurrentUserId]);
 


### PR DESCRIPTION
Make course cards in the dashboard fill the full content width in a single column.

---
<a href="https://cursor.com/background-agent?bcId=bc-21a992ca-85f8-4969-bcdd-7a8469f2d714">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21a992ca-85f8-4969-bcdd-7a8469f2d714">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

